### PR TITLE
Fabric: Base configtxgen download on Ansible host

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/create/channel_artifacts/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/channel_artifacts/tasks/main.yaml
@@ -16,7 +16,7 @@
 # This task fetches the configtx gen tar file from the mentioned URL
 - name: "Geting the configtxgen binary tar"
   get_url:
-    url: https://github.com/hyperledger/fabric/releases/download/v{{network.version}}/hyperledger-fabric-{{fabric.os}}-{{fabric.arch}}-{{network.version}}.tar.gz
+    url: https://github.com/hyperledger/fabric/releases/download/v{{network.version}}/hyperledger-fabric-{{install_os}}-{{install_arch}}-{{network.version}}.tar.gz
     dest: "{{ tmp_directory.path }}"
   when: config_stat_result.stat.exists == False
 
@@ -25,7 +25,7 @@
 # This task unzips the above downloaded tar file
 - name: "Unziping the downloaded file"
   unarchive:
-    src: "{{ tmp_directory.path }}/hyperledger-fabric-{{fabric.os}}-{{fabric.arch}}-{{network.version}}.tar.gz"
+    src: "{{ tmp_directory.path }}/hyperledger-fabric-{{install_os}}-{{install_arch}}-{{network.version}}.tar.gz"
     dest: "{{ tmp_directory.path }}"
   when: config_stat_result.stat.exists == False
 


### PR DESCRIPTION
The configtxgen tool is executed on the Ansible host.
Thus the downloaded version has to be based on the `install_os` and `install_arch` variables.