### PR TITLE
Prettier git output

### DIFF
--- a/platforms/shared/configuration/roles/git_push/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/git_push/tasks/main.yaml
@@ -32,9 +32,9 @@
 # Display output of shell excution
 - name: "Output for gitpush"
   debug:
-    var: GIT_OUTPUT.stdout
+    msg: "{{ GIT_OUTPUT.stdout.split('\n') }}"
 
 # Display error of shell task
 - name: "Error for git_push"
   debug:
-    var: GIT_OUTPUT.stderr
+    msg: "{{ GIT_OUTPUT.stderr.split('\n') }}"


### PR DESCRIPTION
Converts the git push output to a more readable format.

Old format:
```
TASK [/Users/hendrik.leppelsack/Code/blockchain-automation-framework/platforms/hyperledger-fabric/configuration/../../shared/configuration/roles/git_push : Output for gitpush] ***
ok: [localhost] => {
    "GIT_OUTPUT.stdout": "---------------SHOW CONTENT OF DIR---------------\n.\n..\n.git\n.github\n.gitignore\nCODEOWNERS\nCODE_OF_CONDUCT.md\nDockerfile\nLICENSE\nMAINTAINERS.md\nREADME.md\nautomation\nbuild\ndocs\nexamples\nplatforms\nrelease\nrelease-notes.md\nrun.sh\n---------------GIT PUSH---------------\nOn branch develop\nYour branch is ahead of 'origin/develop' by 11 commits.\n  (use \"git push\" to publish your local commits)\n\nnothing to commit, working tree clean"
}
```

New format:
```
ok: [localhost] => {
    "msg": [
        "---------------SHOW CONTENT OF DIR---------------",
        ".",
        "..",
        ".git",
        ".github",
        ".gitignore",
        "CODEOWNERS",
        "CODE_OF_CONDUCT.md",
        "Dockerfile",
        "LICENSE",
        "MAINTAINERS.md",
        "README.md",
        "automation",
        "build",
        "docs",
        "examples",
        "platforms",
        "release",
        "release-notes.md",
        "run.sh",
        "---------------GIT PUSH---------------",
        "[pretty-git 88ad31d] Pushing deployment files for namespace, service accounts and clusterrolebinding",
        " 1 file changed, 1 insertion(+), 1 deletion(-)"
    ]
}
```