### PR TITLE
Indy test on minikube

### DIFF
--- a/docs/source/developer/mac_minikube_setup.md
+++ b/docs/source/developer/mac_minikube_setup.md
@@ -14,6 +14,14 @@ Add minikube executable to your path:  `sudo mv minikube /usr/local/bin`
 
 Let’s confirm the minikube was installed correctly by starting your first cluster:<br/> `minikube start`
 
+*NOTE:* Minikube uses port in range 30000-32767. If you would like to change it, use command bellow:
+
+`minikube start --extra-config=apiserver.service-node-port-range=15000-20000`
+
+*NOTE:* For increase memory of virtual machine of Minikube, use command bellow:
+
+`minikube start --memory 4096`
+
 And now we will check the status: `minikube status`. You should see an output that looks similar to this:
 
 ```
@@ -37,6 +45,10 @@ export PATH=$GOPATH/bin:$PATH
 
 Once you set the GOPATH environment variable, follow the installation guide for [Hashicorp Vault](https://www.vaultproject.io/docs/install/#precompiled-binaries).<br/><br/>
 
+For getting URL address of Vault in minikube, use command bellow:
+
+`minikube service vault --url`
+
 ## Install Ansible using PIP
 
 The recommended method for installing Ansible is to use pip, see    [Ansible instruction](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-pip).
@@ -49,8 +61,31 @@ Add a file called hosts and copy the contents from this [page](https://github.co
 
 
 
-You do not need to install Ambassador in a Dev environment. 
+You do not need to install Ambassador in a Dev environment.
 
+## Install Kubernetes module into Ansible
+
+The recommended module for Ansible is Kubernetes.
+When you have installed Ansible on you Mac, then you install Kubernetes module via pip.
+
+`pip install openshift --user`
+
+or if you use python3, then you use command bellow:
+
+`python3 -m pip install openshift --user`
+
+## Install other prerequisites
+
+### GNU Tar
+Some Ansible roles use Tar for unpack packages. Mac OSX has installed Tar, but the roles use GNU version of Tar tool.
+Use `brew` tool for installation:
+
+`brew install gnu-tar`
+### JQ
+Some Ansible roles use JQ for parsing JSONs and read fields of the JSON objects.
+You need install JQ tool via `brew` tool.
+
+`brew install jq`
 
 ## Editing the network configuration file
 
@@ -74,6 +109,11 @@ k8s:
    context: "minikube"
    config_file: "/Users/username/.kube/config" 
 ```
+
+## Gettin IP address of Minikube for organizations nodes
+If you need public address for nodes in your `network.yaml` file, you can use command bellow:
+
+`minikube ip`
 
  ## Potential issues when using Ansible playbook to setup DLT Network on OSX
 

--- a/platforms/hyperledger-indy/charts/indy-ledger-txn/templates/job.yaml
+++ b/platforms/hyperledger-indy/charts/indy-ledger-txn/templates/job.yaml
@@ -19,7 +19,7 @@ spec:
       restartPolicy: OnFailure
       serviceAccountName: "{{ $.Values.vault.serviceAccountName }}"
       imagePullSecrets:
-        - name: "{{ $.Values.image.pullSecret }}"
+        - name: "{{ $.Values.image.cli.pullSecret }}"
       volumes:
         - name: {{ $.Values.organization.name }}-ptg
           configMap:

--- a/platforms/hyperledger-indy/charts/indy-ledger-txn/templates/job.yaml
+++ b/platforms/hyperledger-indy/charts/indy-ledger-txn/templates/job.yaml
@@ -21,9 +21,9 @@ spec:
       imagePullSecrets:
         - name: "{{ $.Values.image.pullSecret }}"
       volumes:
-        - name: {{ $.Values.metadata.name }}-pool-transactions-genesis
+        - name: {{ $.Values.organization.name }}-ptg
           configMap:
-            name: {{ $.Values.metadata.name }}-ptg
+            name: {{ $.Values.organization.name }}-ptg
         - name: shared-data
           emptyDir:
             medium: Memory
@@ -43,14 +43,11 @@ spec:
            fi
           }
 
-          KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          echo $KUBE_SA_TOKEN;
+          KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token);
           echo "Getting secrets from Vault Server: ${VAULT_ADDR}"
           # Login to Vault to get an approle token
-          VAULT_TOKEN=$(curl -sS --request POST ${VAULT_ADDR}/v1/auth/indy-ns-auth/login \
-            -H "Content-Type: application/json" \
-            -d '{"role":"vault-role","jwt":"'"${KUBE_SA_TOKEN}"'"}' | \
-            jq -r 'if .errors then . else .auth.client_token end')
+          curl --request POST --data '{"jwt": "'"${KUBE_TOKEN}"'", "role": "{{ $.Values.vault.role }}"}' ${VAULT_ADDR}/v1/auth/{{ $.Values.vault.auth_path }}/login | jq -j '.auth.client_token' > token;
+          VAULT_TOKEN=$(cat token);
           validateVaultResponse 'vault login token' "${VAULT_TOKEN}"
           QUERY_RES=$(curl -sS --header "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/$ADMIN_PATH/$ADMIN_NAME/identity/private | jq -r 'if .errors then . else . end')
           validateVaultResponse 'Admin Seed' "${QUERY_RES}"
@@ -66,13 +63,13 @@ spec:
           - name: VAULT_ADDR
             value: "{{ $.Values.vault.address }}"
           - name: ADMIN_PATH
-            value: "{{ $.Values.organization.name.adminIdentity.path }}"
+            value: "{{ $.Values.organization.adminIdentity.path }}"
           - name: ADMIN_NAME
-            value: "{{ $.Values.organization.name.adminIdentity.name }}"
+            value: "{{ $.Values.organization.adminIdentity.name }}"
           - name: IDENTITY_NAME
-            value:  "{{ $.Values.organization.name.newIdentity.name }}"
+            value:  "{{ $.Values.organization.newIdentity.name }}"
           - name: IDENTITY_PATH
-            value: "{{ $.Values.organization.name.newIdentity.path }}"
+            value: "{{ $.Values.organization.newIdentity.path }}"
         volumeMounts:
           - name: shared-data
             mountPath: /data
@@ -86,7 +83,7 @@ spec:
         - |-
           apt-get install curl -y
 
-          ADMIN_SEED=$( cat /data/adminseed.txt)
+          ADMIN_SEED=$( cat /data/seed/adminseed.txt)
           echo "Running ledger Transaction Script...";
 
           ./home/indy-ledger.sh $ADMIN_DID $ADMIN_SEED $IDENTITY_DID $IDENTITY_ROLE $IDENTITY_VERKEY $POOL_GENESIS_PATH;
@@ -99,17 +96,17 @@ spec:
           - name: VAULT_ADDR
             value: "{{ $.Values.vault.address }}"
           - name: ADMIN_DID
-            value: "{{ $.Values.organization.name.adminIdentity.did }}"
+            value: "{{ $.Values.organization.adminIdentity.did }}"
           - name: IDENTITY_DID
-            value:  "{{ $.Values.organization.name.newIdentity.did }}"
+            value:  "{{ $.Values.organization.newIdentity.did }}"
           - name: IDENTITY_ROLE
-            value: "{{ $.Values.organization.name.newIdentity.role }}"
+            value: "{{ $.Values.organization.newIdentity.role }}"
           - name: IDENTITY_VERKEY
-            value: "{{ $.Values.organization.name.newIdentity.verkey }}"
+            value: "{{ $.Values.organization.newIdentity.verkey }}"
           - name: POOL_GENESIS_PATH
             value: /var/lib/indy/genesis/{{ $.Values.network.name }}/pool_transactions_genesis
         volumeMounts:
-          - name: {{ $.Values.metadata.name }}-pool-transactions-genesis
+          - name: {{ $.Values.organization.name }}-ptg
             mountPath: /var/lib/indy/genesis/{{ $.Values.network.name }}/pool_transactions_genesis
             subPath: pool_transactions_genesis
           - name: shared-data

--- a/platforms/hyperledger-indy/charts/indy-ledger-txn/values.yaml
+++ b/platforms/hyperledger-indy/charts/indy-ledger-txn/values.yaml
@@ -18,40 +18,41 @@ network:
 
 organization:
   name:
-    adminIdentity:
-      #Provide the admin identity name
-      #Eg. name: admin_name
-      name: 
+    #Provide the organization name
+  adminIdentity:
+    #Provide the admin identity name
+    #Eg. name: admin_name
+    name:
 
-      #Provide the admin identity path
-      #Eg. path: admin_path
-      path: 
+    #Provide the admin identity path
+    #Eg. path: admin_path
+    path:
 
-    newIdentity:
-      #Provide the new identity name
-      #Eg. name: identity_name
-      name:
+  newIdentity:
+    #Provide the new identity name
+    #Eg. name: identity_name
+    name:
 
-      #Provide the new identity path
-      #Eg. path: identity_path
-      path: 
+    #Provide the new identity path
+    #Eg. path: identity_path
+    path:
 
-      #Provide the new identity role
-      #Eg. role: identity_role
-      role: 
+    #Provide the new identity role
+    #Eg. role: identity_role
+    role:
 
-      #Provide the new identity did
-      #Eg. did: identity_did
-      did:
+    #Provide the new identity did
+    #Eg. did: identity_did
+    did:
 
-      #Provide the new identity did
-      #Eg. verkey: verification key value
-      verkey:
+    #Provide the new identity did
+    #Eg. verkey: verification key value
+    verkey:
 
 image:
   cli: 
     #Provide the image name for the indy-ledger-txn container
-    #Eg. name: indy-ledget-txn
+    #Eg. name: indy-ledger-txn
     name: 
 
     #Provide the image repository for the indy-ledger-txn container

--- a/platforms/hyperledger-indy/charts/indy-node/templates/service.yaml
+++ b/platforms/hyperledger-indy/charts/indy-node/templates/service.yaml
@@ -9,12 +9,19 @@ metadata:
     {{ $.Values.ambassador.annotations  | nindent 6 }}
   {{ end }}
 spec:
+  type: {{ $.Values.service.type }}
   ports:
   - name: indy-node-node
     port: {{ $.Values.service.ports.nodePort }}
     targetPort: {{ $.Values.service.ports.nodeTargetPort }}
+    {{ if eq $.Values.service.type "NodePort" }}
+    nodePort: {{ $.Values.service.ports.nodeTargetPort }}
+    {{ end }}
   - name: indy-node-client
     port: {{ $.Values.service.ports.clientPort }}
     targetPort: {{ $.Values.service.ports.clientTargetPort }}
+    {{ if eq $.Values.service.type "NodePort" }}
+    nodePort: {{ $.Values.service.ports.clientTargetPort }}
+    {{ end }}
   selector:
     app: "{{ $.Values.metadata.name }}"

--- a/platforms/hyperledger-indy/charts/indy-node/values.yaml
+++ b/platforms/hyperledger-indy/charts/indy-node/values.yaml
@@ -71,6 +71,8 @@ client:
   port:
 
 service:
+  type:
+    #Provide type of service (NodePort/ClusterIp)
   ports:
     #Provide the service node port
     #Eg. nodePort: 9711

--- a/platforms/hyperledger-indy/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-indy/configuration/deploy-network.yaml
@@ -163,6 +163,8 @@
       organization: "{{ organizationItem.name | lower }}"
       component_ns: "{{ organizationItem.name | lower }}-ns"
       kubernetes: "{{ organizationItem.k8s }}"
+      gitops: "{{ organizationItem.gitops }}"
+      vault: "{{ organizationItem.vault }}"
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: organizationItem

--- a/platforms/hyperledger-indy/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-indy/configuration/deploy-network.yaml
@@ -108,6 +108,7 @@
     loop_control:
       loop_var: organizationItem
     when: network['type'] == 'indy'
+
   # Generate indy crypto and insert into Vault
   - name: 'Generate indy crypto and insert into Vault'
     include_role:
@@ -158,6 +159,13 @@
   - name: 'Create Endorser Identities'
     include_role:
       name: setup/endorsers
+    vars:
+      organization: "{{ organizationItem.name | lower }}"
+      component_ns: "{{ organizationItem.name | lower }}-ns"
+      kubernetes: "{{ organizationItem.k8s }}"
+    loop: "{{ network['organizations'] }}"
+    loop_control:
+      loop_var: organizationItem
     when: network['type'] == 'indy'
 
   # delete build directory

--- a/platforms/hyperledger-indy/configuration/roles/check/validation/tasks/check_count.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/check/validation/tasks/check_count.yaml
@@ -10,7 +10,7 @@
 - name: "Counting trustees per Org"
   set_fact:
     trustee_count={{ trustee_count|default(0)|int + 1 }}
-    total_trustees={{ total_trustees||default(0)int + 1 }}
+    total_trustees={{ total_trustees|default(0)|int + 1 }}
   loop: "{{ trustees }}"
 
 - name: Print error and end playbook if trustee count limit fails
@@ -25,3 +25,9 @@
 - name: Print error abd end playbook  if endorser count limit fails
   debug: msg="The endorser count is {{ endorser_count }}. There should be max 1 endorser per organization."
   failed_when: endorser_count|int > 1
+  when: endorser_count is defined
+
+- name: Reset Endorser count
+  set_fact:
+    endorser_count=0
+  when: endorser_count is defined

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/auth_job/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/auth_job/tasks/main.yaml
@@ -14,7 +14,7 @@
 # This tasks gets the kubernetes server url
 - name: Get the kubernetes server url
   shell: |
-    cat {{ kubernetes.config_file }} | grep server: |  awk '{print $2}'
+    kubectl config view --minify | grep server | cut -f 2- -d ":" | tr -d " "
   register: kubernetes_server_url
 
 ##############################################################################################

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/ledger_txn/tasks/nested_main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/ledger_txn/tasks/nested_main.yaml
@@ -1,8 +1,16 @@
+##############################################################################################
+# This tasks ensures the directory of crypto existance, if not exits it creates a new one
+- name: Ensures {{ release_dir }}/{{ component_type }}/{{ component_name }} dir exists
+  file:
+    path: "{{ release_dir }}/{{ new_component_name }}/"
+    recurse: yes
+    state: directory
+
 ################################################################################################
 # This tasks gets data from vault
 - name: Get identity data from vault
   shell: |
-  
+    rm data.yaml
     identity_data=""
     trustee_name={{ admin_name }}
     trustee_did=$(curl --header "X-Vault-Token:{{ ac_vault_tokens[admin_component_name] }}" "{{ admin_org_vault_url }}"/v1/"{{ admin_component_name }}"/"{{ admin_type }}"/"{{ admin_name }}"/identity/public | jq -r 'if .errors then . else .data.did end');
@@ -16,10 +24,9 @@
     echo "${identity_data}" >> data.yaml
     identity_data="trustee_verkey: ${trustee_verkey}"
     echo "${identity_data}" >> data.yaml
-            
 
     endorser_name={{ identity_name }}
-    endorser_did=$(curl --header "X-Vault-Token: {{ ac_vault_tokens[new_component_name] }}" "{{ new_org_vault_url }}"/v1/"{{ new_component_name }}"/"{{ identity_type }}"/"{{ identity_name }}"/identity/public | jq -r 'if .errors then . else .data.did end');  
+    endorser_did=$(curl --header "X-Vault-Token: {{ ac_vault_tokens[new_component_name] }}" "{{ new_org_vault_url }}"/v1/"{{ new_component_name }}"/"{{ identity_type }}"/"{{ identity_name }}"/identity/public | jq -r 'if .errors then . else .data.did end');
     endorser_verkey=$(curl --header "X-Vault-Token: {{ ac_vault_tokens[new_component_name] }}" "{{ new_org_vault_url }}"/v1/"{{ new_component_name }}"/"{{ identity_type }}"/"{{ identity_name }}"/node/public/verif_keys | jq -r 'if .errors then . else .data."verification-key" end');
 
     identity_data="endorser_name: ${endorser_name}"
@@ -28,18 +35,17 @@
     echo "${identity_data}" >> data.yaml
     identity_data="endorser_verkey: ${endorser_verkey}"
     echo "${identity_data}" >> data.yaml
-
   register: identity_data
 
 - name: Debugging
   debug:
     msg: "the value file is {{lookup('file', 'data.yaml') }}"
-    
+
 - name: "Inserting into file"
   include_vars:
     file: data.yaml
     name: file_var
-  
+
 ##############################################################################################
 # This task creates deployment file for new identities.
 - name: "create value file for {{ new_component_name }} {{ component_type }}"
@@ -50,11 +56,11 @@
     values_file: "{{ release_dir }}/{{ new_component_name }}/{{ identity_name }}-{{ component_type }}.yaml"
     chart: "indy-ledger-txn"
     identity_name: "{{ identity_name }}"
-    auth_path: "{{ component_ns }}-auth"
-    
+    vault_role: "rw"
+
 - name: "Delete file"
   shell: |
-    rm data.yaml    
+    rm data.yaml
 
 ################################################################################################
 # This task tests the value file for syntax errors/ missing values

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/ledger_txn/templates/ledger-txn.tpl
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/ledger_txn/templates/ledger-txn.tpl
@@ -1,19 +1,19 @@
 apiVersion: flux.weave.works/v1beta1
 kind: HelmRelease
 metadata:
-  name: {{ component_name }}-{{ identity_name }}
+  name: {{ component_name }}-{{ identity_name }}-transaction
   annotations:
     flux.weave.works/automated: "false"
   namespace: {{ component_ns }}
 spec:
-  releaseName: {{ component_name }}-{{ identity_name }}
+  releaseName: {{ component_name }}-{{ identity_name }}-transaction
   chart:
     path: {{ gitops.chart_source }}/{{ chart }}
     git: {{ gitops.git_ssh }}
     ref: {{ gitops.branch }}
   values:
     metadata:
-      name: {{ component_name }}-{{ identity_name }}
+      name: {{ component_name }}-{{ identity_name }}-transaction
       namespace: {{ component_ns }}
     network:
       name: {{ network.name }}
@@ -24,18 +24,20 @@ spec:
         pullSecret: regcred
     vault:
       address: {{ vault.url }}
-      role: {{ vault.role }}
-      serviceAccountName: {{ vault.serviceAccountName }}
-      authpath: {{ auth_path }}
+      role: {{ vault_role }}
+      serviceAccountName: {{ component_name }}-admin-vault-auth
+      auth_path: kubernetes-{{ component_name }}-admin-auth
     organization:
-      name: 
-        adminIdentity:
-          name: {{ file_var.trustee_name }}
-          did: {{ file_var.trustee_did }}
-        newIdentity:
-          name: {{ file_var.endorser_name }}
-          role: {{ newIdentity_role }}
-          did: {{ file_var.endorser_did }}
-          verkey: {{ file_var.endorser_verkey }}
+      name: {{ component_name }}
+      adminIdentity:
+        name: {{ file_var.trustee_name }}
+        did: {{ file_var.trustee_did }}
+        path: {{ admin_component_name }}/{{ admin_type }}
+      newIdentity:
+        name: {{ file_var.endorser_name }}
+        role: {{ newIdentityRole }}
+        did: {{ file_var.endorser_did }}
+        verkey: {{ file_var.endorser_verkey }}
+        path: {{ component_name }}/endorsers
     node:
       name: {{ component_name }}

--- a/platforms/hyperledger-indy/configuration/roles/create/helm_component/node/templates/node.tpl
+++ b/platforms/hyperledger-indy/configuration/roles/create/helm_component/node/templates/node.tpl
@@ -35,6 +35,11 @@ spec:
       ip: 0.0.0.0
       port: {{ stewardItem.client.port }}
     service:
+{% if organizationItem.cloud_provider != 'minikube' %}
+      type: ClusterIP
+{% else %}
+      type: NodePort
+{% endif %}
       ports:
         nodePort: {{ stewardItem.node.port }}
         nodeTargetPort: {{ stewardItem.node.targetPort }}
@@ -61,6 +66,7 @@ spec:
         # Directory to store node info.
         NODE_INFO_DIR = '/var/lib/indy/data'
     ambassador:
+{% if organizationItem.cloud_provider != 'minikube' and network.env.proxy == 'ambassador' %}
       annotations: |-
         ---
         apiVersion: ambassador/v1
@@ -74,6 +80,9 @@ spec:
         name: {{ component_name|e }}-client-mapping
         port: {{ stewardItem.client.ambassador }}
         service: {{ component_name|e }}.{{ component_ns }}:{{ stewardItem.client.targetPort }}
+{% else %}
+      disabled: true
+{% endif %}
     vault:
       address: {{ vault.url }}
       serviceAccountName: {{ organizationItem.name }}-{{ stewardItem.name }}-vault-auth

--- a/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/main.yaml
@@ -27,7 +27,4 @@
       newIdentity: "{{ organizationItem.services.endorsers }}"
       component_ns: "{{ organizationItem.name | lower }}-ns"
       org_vault_url: "{{ organizationItem.vault.url}}"
-    loop: "{{ organizations }}"
-    loop_control:
-      loop_var: organizationItem
     when: organizationItem is defined

--- a/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/main.yaml
@@ -27,4 +27,4 @@
       newIdentity: "{{ organizationItem.services.endorsers }}"
       component_ns: "{{ organizationItem.name | lower }}-ns"
       org_vault_url: "{{ organizationItem.vault.url}}"
-    when: organizationItem is defined
+    when: organizationItem is defined and organizationItem.services.endorsers is defined

--- a/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/nested_main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/nested_main.yaml
@@ -12,7 +12,8 @@
     global_Org=""
     admin_url=""
     global_url=""
-    type=""
+    global_type=""
+    admin_type=""
     {% if network['organizations'] is defined %}
       {% for organization in network['organizations'] %}
         first_admin_in_org=""
@@ -25,7 +26,7 @@
                 first_admin_in_org="{{ trustee.name }}"
                 admin_Org="{{ organization.name }}"
                 admin_url="{{ organization.vault.url }}"
-                type="trustees"
+                admin_type="trustees"
               fi
             fi
             if [ -z "$first_global_admin" ]
@@ -33,7 +34,7 @@
               first_global_admin="{{ trustee.name }}"
               global_Org="{{ organization.name }}"
               global_url="{{ organization.vault.url }}"
-              type="trustees"
+              global_type="trustees"
             fi
           {% endfor %}
         {% endif %}
@@ -46,7 +47,7 @@
                 first_admin_in_org="{{ steward.name }}"
                 admin_Org="{{ organization.name }}"
                 admin_url="{{ organization.vault.url }}"
-                type="stewards"
+                admin_type="stewards"
               fi
             fi
             if [ -z "$first_global_admin" ]
@@ -54,7 +55,7 @@
               first_global_admin="{{ steward.name }}"
               global_Org="{{ organization.name }}"
               global_url="{{ organization.vault.url }}"
-              type="stewards"
+              global_type="stewards"
             fi
           {% endfor %}
         {% endif %}
@@ -66,16 +67,18 @@
       selectedAdmin="${first_admin_in_org}"
       adminUrl="${admin_url}"
       adminOrg="${admin_Org}"
+      admin_type="${admin_type}"
     else
       selectedAdmin="${first_global_admin}"
       adminUrl="${global_url}"
       adminOrg="${global_Org}"
+      admin_type="${global_type}"
     fi
     rm -rf admin.yaml
     echo "selectedAdmin: ${selectedAdmin}" >> admin.yaml
     echo "adminUrl: ${adminUrl}" >> admin.yaml
     echo "adminOrg: ${adminOrg}" >> admin.yaml
-    echo "type: ${type}" >> admin.yaml
+    echo "type: ${admin_type}" >> admin.yaml
   register: admin_file
 
 #----------------------------------------------------------------------------------------------

--- a/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/nested_main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/setup/endorsers/tasks/nested_main.yaml
@@ -6,7 +6,6 @@
 ---
 - name: Select Admin Identity for Organisation {{ component_name }}
   shell: |
-  
     selectedAdmin=""
     first_global_admin=""
     admin_Org=""
@@ -21,7 +20,7 @@
           {% for trustee in organization.services.trustees %}
             if [ -z "$first_admin_in_org" ]
             then
-              if [ organization.name == "{{ component_name }}" ]
+              if [ {{ organization.name }} == "{{ component_name }}" ]
               then
                 first_admin_in_org="{{ trustee.name }}"
                 admin_Org="{{ organization.name }}"
@@ -38,12 +37,11 @@
             fi
           {% endfor %}
         {% endif %}
-        
         {% if organization.services.stewards is defined %}
           {% for steward in organization.services.stewards %}
             if [ -z "$first_admin_in_org" ]
             then
-              if [ organization.name == "{{ component_name }}" ]
+              if [ {{ organization.name }} == "{{ component_name }}" ]
               then
                 first_admin_in_org="{{ steward.name }}"
                 admin_Org="{{ organization.name }}"
@@ -62,23 +60,23 @@
         {% endif %}
       {% endfor %}
     {% endif %}
-    
-    if [ -z "$first_admin_in_org" ]
-      then
-        selectedAdmin="${first_admin_in_org}"
-        adminUrl="${admin_url}"
-        adminOrg="${admin_Org}"
-      else
-        selectedAdmin="${first_global_admin}"
-        adminUrl="${global_url}"
-        adminOrg="${global_Org}"
+
+    if [ ! -z "$first_admin_in_org" ]
+    then
+      selectedAdmin="${first_admin_in_org}"
+      adminUrl="${admin_url}"
+      adminOrg="${admin_Org}"
+    else
+      selectedAdmin="${first_global_admin}"
+      adminUrl="${global_url}"
+      adminOrg="${global_Org}"
     fi
-    echo "${selectedAdmin}" >> admin.yaml
-    echo "${adminUrl}" >> admin.yaml
-    echo "${adminOrg}" >> admin.yaml
-    echo "${type}" >> admin.yaml
-    
-  register: admin.yaml
+    rm -rf admin.yaml
+    echo "selectedAdmin: ${selectedAdmin}" >> admin.yaml
+    echo "adminUrl: ${adminUrl}" >> admin.yaml
+    echo "adminOrg: ${adminOrg}" >> admin.yaml
+    echo "type: ${type}" >> admin.yaml
+  register: admin_file
 
 #----------------------------------------------------------------------------------------------
 - name: "Inserting into file"
@@ -94,30 +92,30 @@
   debug:
     msg: "the value file is {{lookup('file', 'admin.yaml') }}"
 
-#----------------------------------------------------------------------------------------------    
+#----------------------------------------------------------------------------------------------
 # Create Deployment files for new Identities
 - name: "Calling Helm Release Development Role..."
   include_role:
-    name: ledger_txn
-    vars:
-      component_type: "identity"
-      component_name: "{{ organizationItem.name }}"
-      indy_version: "indy-{{ network.version }}"
-      release_dir: "{{playbook_dir}}/../../../{{organizationItem.gitops.release_dir}}/{{ organizationItem.name | lower }}"
-      component_ns: "{{ organizationItem.name | lower }}-ns"
-      newIdentityName: "{{ newIdentityItem.name }}"
-      newIdentityRole: "ENDORSER"
-      adminIdentityName: "{{ admin_var.selectedAdmin }}"
-      admin_component_name: "{{ admin_var.Org }}"
-      admin_org_vault_url: "{{ admin_var.adminUrl }}"
-      new_org_vault_url: "{{ organizationItem.vault.url}}"
-      new_component_name: "{{ component_name }}"
-      admin_type: "{{ admin_var.type }}"
-      identity_type: "endorsers"
-    loop: "{{ newIdentity }}"
-    loop_control:
-      loop_var: newIdentityItem
-    when: newIdentity is defined
+    name: create/helm_component/ledger_txn
+  vars:
+    component_type: "identity"
+    component_name: "{{ organizationItem.name }}"
+    indy_version: "indy-{{ network.version }}"
+    release_dir: "{{playbook_dir}}/../../../{{organizationItem.gitops.release_dir}}/{{ organizationItem.name | lower }}"
+    component_ns: "{{ organizationItem.name | lower }}-ns"
+    newIdentityName: "{{ newIdentityItem.name }}"
+    newIdentityRole: "ENDORSER"
+    adminIdentityName: "{{ admin_var.selectedAdmin }}"
+    admin_component_name: "{{ admin_var.adminOrg }}"
+    admin_org_vault_url: "{{ admin_var.adminUrl }}"
+    new_org_vault_url: "{{ organizationItem.vault.url}}"
+    new_component_name: "{{ component_name }}"
+    admin_type: "{{ admin_var.type }}"
+    identity_type: "endorsers"
+  loop: "{{ newIdentity }}"
+  loop_control:
+    loop_var: newIdentityItem
+  when: newIdentity is defined
 
 - name: "Delete file"
   shell: |
@@ -135,4 +133,4 @@
     GIT_PASSWORD: "{{ gitops.password }}"
     GIT_BRANCH: "{{ gitops.branch }}"
     GIT_RESET_PATH: "platforms/hyperledger-indy/configuration"
-  msg: "Pushing deployment files"
+    msg: "Pushing deployment files"

--- a/platforms/hyperledger-indy/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/hyperledger-indy/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -58,7 +58,7 @@
 - name: Write reviewer token for Organizations
   shell: |
     export REVIEWER_TOKEN=$(KUBECONFIG={{ kubernetes.config_file }} kubectl get secret $(KUBECONFIG={{ kubernetes.config_file }} kubectl get serviceaccount {{ organization }}-admin-vault-auth -n {{ component_ns }} -o jsonpath={.secrets[0].name}) -n {{ component_ns }} -o  jsonpath={.data.token} | base64 --decode)
-    vault write auth/{{ auth_path }}/config token_reviewer_jwt="$REVIEWER_TOKEN" kubernetes_host=$(KUBECONFIG={{ kubernetes.config_file }} kubectl config view -o jsonpath="{.clusters[?(@.name==\"{{ kubernetes.context }}\")].cluster.server}") kubernetes_ca_cert=@"./build/{{ organization }}.ca.cert"
+    vault write auth/{{ auth_path }}/config token_reviewer_jwt="$REVIEWER_TOKEN" kubernetes_host="$(KUBECONFIG={{ kubernetes.config_file }} kubectl config view --minify | grep server | cut -f 2- -d ":" | tr -d " ")" kubernetes_ca_cert=@"./build/{{ organization }}.ca.cert"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-indy/images/indy-cli/indy-ledger.sh
+++ b/platforms/hyperledger-indy/images/indy-cli/indy-ledger.sh
@@ -80,7 +80,6 @@ else
 	exit 1
 fi
 
-
 echo "wallet open myIndyWallet key=12345
 did use $admin_did
 pool connect sandboxpool
@@ -89,7 +88,7 @@ ledger get-nym did=$identity_did" > indy_txn.txt;
 
 indy-cli indy_txn.txt > txn_result.txt;
 
-if grep -Fxq "Following NYM has been received" txn_result.txt
+if grep -Fxq "Following NYM has been received." txn_result.txt
 then
 	echo "Transaction Successful, NYM has been received";
 	exit 0

--- a/platforms/hyperledger-indy/images/indy-cli/indy-ledger.sh
+++ b/platforms/hyperledger-indy/images/indy-cli/indy-ledger.sh
@@ -56,7 +56,7 @@ did use $admin_did
 exit" > indy_txn.txt;
 
 indy-cli indy_txn.txt > txn_result.txt;
-if grep -q 'Did \"$admin_did\" has been set as active' 'txn_result.txt'
+if grep -Fxq "Did \"$admin_did\" has been set as active" txn_result.txt
 then
 	echo "DID set active.";
 else
@@ -72,7 +72,7 @@ pool list
 exit" > indy_txn.txt;
 
 indy-cli indy_txn.txt > txn_result.txt
-if grep -q 'Pool "sandboxpool" has been connected' 'txn_result.txt'
+if grep -Fxq "Pool \"sandboxpool\" has been connected" txn_result.txt
 then
 	echo "Pool successfully Connected";
 else
@@ -89,7 +89,7 @@ ledger get-nym did=$identity_did" > indy_txn.txt;
 
 indy-cli indy_txn.txt > txn_result.txt;
 
-if grep -q 'Following NYM has been received' 'txn_result.txt'
+if grep -Fxq "Following NYM has been received" txn_result.txt
 then
 	echo "Transaction Successful, NYM has been received";
 	exit 0

--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -37,7 +37,7 @@
     AWS_SECRET_ACCESS_KEY: "{{ aws.secret_key }}"
   shell: |
     # format ip addresses list to string with space separator
-    ips=$(echo '{{ item.aws.publicIps }}' | tr -d '[]' | sed 's/,/\ /g')
+    ips=$(echo '{{ item.publicIps }}' | tr -d '[]' | sed 's/,/\ /g')
     data=$(aws ec2 describe-addresses --public-ips ${ips} --region {{ aws.region }} --output json | jq '.Addresses[].AllocationId')
     # format eip addresses list to string with comma separator (comma has to be escaped)
     echo ${data} | tr -d '"' | sed 's/\ /\\,/g'


### PR DESCRIPTION
Fixed bugs:
 - charts/indy-ledger-txn:
    - wrong volume names
    - printing Kubernetes Token on console out
    - wrong Vault Role for access to auth method via service account
    - wrong path to seed in file
 - deploy-network:
    - Role: 'Create Endorser Identities':
       - missing needed variables (undefined variables in nested tasks)
 - check-count:
    - typo in function
    - missing task to reset variable for counting (wrong counting of Endorser in Organization)
 - auth_job:
    - wrong getting address of Kubernetes (new function returns still only one -> this is correct)
 - ledger_txn:
    - missing task to check if release directory exists
    - the same name of HelmRelease, which exists in BAF
    - wrong service account name
    - wrong  auth path
    - typo of variable names
  - setup/endorser:
    - missing loop of organization
    - missing {{}} for variable
    - wrong define yaml file -> missing keys
    - calling of not exist key
    - wrong indent of task fields

Changes:
 - charts/indy-ledger-txn:
    - value file
 - charts/indy-node:
    - add functionality to create NodePort type for service, when is running on Minikube

Updated documentation for setup BAF on Minikube
 - added prerequisites

Checked via Indy-Cli:
<img width="755" alt="Screenshot 2020-02-29 at 20 03 56" src="https://user-images.githubusercontent.com/56829667/75783145-5acf4c80-5d60-11ea-8e2d-0aaf80cdd345.png">

<img width="775" alt="Screenshot 2020-02-29 at 20 04 07" src="https://user-images.githubusercontent.com/56829667/75783152-5e62d380-5d60-11ea-83c2-76d23ee05ae4.png">
