### PR TITLE
[indy] Fix creating a list steward's port for ambassador (#674)

### DIFF
--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -13,21 +13,19 @@
     do
       steward=$( echo ${json} | jq ".[${index}]")
       name=$(echo ${steward} | jq '.name' | tr -d '"')
-      ip=$(echo ${steward} | jq '.publicIp' | sed 's/\./_/g' | sed 's/"/ip/g')
       node_port=$(echo ${steward} | jq '.node.ambassador' | tr -d '"')
       client_port=$(echo ${steward} | jq '.client.ambassador' | tr -d '"')
       if [[ ${name} != null ]]
       then
-        if [[ ${ports["${ip}"]} != "" ]]
+        if [[ ${ports["{{ kubecontext }}"]} != "" ]]
         then
-          ports+=( ["${ip}"]+=, )
+          ports+=( ["{{ kubecontext }}"]+=, )
         fi
-        ports+=( ["${ip}"]+=${node_port},${client_port} )
+        ports+=( ["{{ kubecontext }}"]+=${node_port},${client_port} )
       fi
       index=$(( ${index} + 1 ))
     done
-    key=ip$(echo {{ item.services.stewards[0].publicIp }} | sed 's/\./_/g')ip
-    echo ${ports["${key}"]}
+    echo ${ports["{{ kubecontext }}"]}
   register: terminal
   when: network['type'] == 'indy' and item.services.stewards is defined
   tags:


### PR DESCRIPTION
Signed-off-by: VladimirDzamba <vladimir.dzamba@accenture.com>

**Changelog**
- Update Ansible role for create steward's port list. Change group by IP of steward to group by kubecontext (group by k8s cluster)

 

**Reviewed by**
@sownak 

 

**Linked issue**
#674 
