### PR TITLE
Specifying  molecule version to 3.0.6 for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ _molecule: &molecule
   python:
     - "3.6"
   install:
-    - pip install molecule yamllint ansible-lint docker==4.2.2 openshift
+    - pip install molecule==3.0.6 yamllint ansible-lint docker==4.2.2 openshift
     - export DOCKER_API_VERSION='1.38'
   script:
     - cd $DIR


### PR DESCRIPTION
Signed-off-by: suvajit-sarkar <suvajit.sarkar@accenture.com>

**Changelog**
- Add specific molecule version for travis ci