### PR TITLE
[ Corda-Ent ] General fixes for code uniformity across Corda Opensource and Corda Enterprise platforms

### DIFF
--- a/platforms/corda-ent/charts/idman/templates/pvc.yaml
+++ b/platforms/corda-ent/charts/idman/templates/pvc.yaml
@@ -19,7 +19,7 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 256Mi
+      storage: 64Mi
 
 ---
 apiVersion: v1
@@ -42,4 +42,4 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 256Mi
+      storage: 64Mi

--- a/platforms/corda-ent/charts/nmap/templates/pvc.yaml
+++ b/platforms/corda-ent/charts/nmap/templates/pvc.yaml
@@ -19,7 +19,7 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 256Mi
+      storage: 64Mi
 
 ---
 apiVersion: v1
@@ -42,7 +42,7 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 256Mi
+      storage: 64Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -64,4 +64,4 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 256Mi
+      storage: 64Mi

--- a/platforms/corda-ent/charts/node/templates/pvc.yaml
+++ b/platforms/corda-ent/charts/node/templates/pvc.yaml
@@ -19,4 +19,4 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 256Mi
+      storage: 64Mi

--- a/platforms/corda-ent/charts/notary/templates/pvc.yaml
+++ b/platforms/corda-ent/charts/notary/templates/pvc.yaml
@@ -19,4 +19,4 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 256Mi
+      storage: 64Mi

--- a/platforms/corda-ent/configuration/deploy-network.yaml
+++ b/platforms/corda-ent/configuration/deploy-network.yaml
@@ -30,13 +30,14 @@
     include_role:
       name: create/storageclass
     vars:
-      storageclass_name: "cenmsc"
+      storageclass_name: "cordaentsc"
       git_dir: "{{ org.gitops.release_dir }}"
       org: "{{ org }}"
       kubernetes: "{{ org.k8s }}"
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: org
+
   # ----------------------------------------------------------------------  
   # Setup Vault-Kubernetes accesses and Regcred for docker registry
   - name: "Setup vault"   
@@ -81,50 +82,10 @@
       name: setup/networkroottruststore
 
   # ----------------------------------------------------------------------   
-  # Create ambassador certificates for idman
-  - name: Create ambassador certificates for idman
-    include_role:
-      name: create/certificates/ambassador/idman
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-    when: org.type == 'cenm'
-
-  # ----------------------------------------------------------------------   
-  # Create ambassador certificates for nmap
-  - name: Create ambassador certificates for nmap
-    include_role:
-      name: create/certificates/ambassador/nmap
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-    when: org.type == 'cenm'
-
-  # ----------------------------------------------------------------------   
-  # Create ambassador certificates for notary
-  - name: Create ambassador certificates for notary
-    include_role:
-      name: create/certificates/ambassador/notary
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-    when: org.type == 'cenm'
-
-  # ----------------------------------------------------------------------   
   # Create value file for idman
   - name: Create value file for idman
     include_role:
       name: setup/idman
-    loop: "{{ network['organizations'] }}"
-    loop_control:
-      loop_var: org
-    when: org.type == 'cenm'
-
-  # ----------------------------------------------------------------------   
-  # Create value file for notary-initial-registration 
-  - name: Create value file for notary registration job
-    include_role:
-      name: setup/notary-initial-registration
     loop: "{{ network['organizations'] }}"
     loop_control:
       loop_var: org

--- a/platforms/corda-ent/configuration/roles/create/certificates/ambassador/idman/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/create/certificates/ambassador/idman/tasks/main.yaml
@@ -2,10 +2,16 @@
 # and places them in vault. Certificates are created using openssl
 # This also creates the corresponding Kubernetes secret
 ---
+
+# Set variable for idman tls certificate path
+- name: Set variable for idman tls certificate path
+  set_fact:
+    idman_tlscert_path: "{{ network | json_query('orderers[?type==`idman`].certificate') | first }}"
+
 # check if the ambassador tls directory exists
 - name: "Check if the ambassador directory exists or not"
   stat:
-    path: "./build/ambassador/{{ org.services.idman.name }}"
+    path: "{{ idman_tlscert_path | dirname }}"
   register: ambassadordir_check
 
 # Create the ambassador directory if it doesn't exist
@@ -14,7 +20,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
   vars:
     check: "ensure_dir"
-    path: "./build/ambassador/{{ org.services.idman.name }}"
+    path: "{{ idman_tlscert_path | dirname }}"
   when: not ambassadordir_check.stat.exists
 
 # Check if the ambassador tls is already created
@@ -34,7 +40,7 @@
   vars:
     vault_output: "{{ ambassador_tls_certs.stdout | from_yaml }}"
     type: "ambassador"
-    cert_path: "./build/ambassador/{{ org.services.idman.name }}"
+    cert_path: "{{ idman_tlscert_path | dirname }}"
   when: ambassador_tls_certs.failed == False
 
 # Check if ambassadortls dir is there
@@ -46,7 +52,7 @@
 # Generates the openssl file for domain
 - name: Generate openssl conf file
   shell: |
-    cd ./build/ambassador/{{ org.services.idman.name }}
+    cd {{ idman_tlscert_path | dirname }}
     cat <<EOF >openssl{{ org.services.idman.name }}.conf
     [dn]
     CN={{ domain_name }}
@@ -76,20 +82,20 @@
 # Check if the rootca.jks is already present or not
 - name: Check if rootca.jks is present
   stat:
-    path: "./build/ambassador/{{ org.services.idman.name }}/rootca.jks"
+    path: "{{ idman_tlscert_path | dirname }}/rootca.jks"
   register: check_rootcajks
 
 # Store the rootca.jks in build folder if it doesn't exist
 - name: Store the keystore in a file
   copy:
     content: "{{ subordinateca.stdout | b64decode }}"
-    dest: "./build/ambassador/{{ org.services.idman.name }}/rootca.jks"
+    dest: "{{ idman_tlscert_path | dirname }}/rootca.jks"
   when: not check_rootcajks.stat.exists
 
 # Create ambassador certificates
 - name: Create ambassador certificates
   shell: |
-    cd ./build/ambassador/{{ org.services.idman.name }}
+    cd {{ idman_tlscert_path | dirname }}
     keytool -importkeystore -srckeystore rootca.jks -destkeystore rootca.p12 -deststoretype PKCS12 -srcalias subordinateca -deststorepass password -srcstorepass password
     keytool -export -alias subordinateca -keystore rootca.jks -rfc -file rootca.pem -storepass password
     openssl pkcs12 -in rootca.p12  -nodes -nocerts -out key.pem -passin pass:'password'
@@ -101,7 +107,7 @@
 # Store the ambassador certificates into the vault
 - name: Store the ambassador certs to vault
   shell: |
-    vault kv put secret/{{ org.name | lower }}/{{ org.services.idman.name }}/tlscerts tlscacerts="$(cat ./build/ambassador/{{ org.services.idman.name }}/ambassador.pem | base64)" tlskey="$(cat ./build/ambassador/{{ org.services.idman.name }}/ambassador.key | base64)"
+    vault kv put secret/{{ org.name | lower }}/{{ org.services.idman.name }}/tlscerts tlscacerts="$(cat {{ idman_tlscert_path | dirname }}/ambassador.pem | base64)" tlskey="$(cat {{ idman_tlscert_path | dirname }}/ambassador.key | base64)"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -120,5 +126,5 @@
 # Create the ambassador secret if it doesn't exist
 - name: Create the ambassador credentials
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} kubectl create secret tls {{ org.services.idman.name }}-ambassador-certs --cert="./build/ambassador/{{ org.services.idman.name }}/ambassador.pem" --key="./build/ambassador/{{ org.services.idman.name }}/ambassador.key" -n default
+    KUBECONFIG={{ org.k8s.config_file }} kubectl create secret tls {{ org.services.idman.name }}-ambassador-certs --cert="{{ idman_tlscert_path | dirname }}/ambassador.pem" --key="{{ idman_tlscert_path | dirname }}/ambassador.key" -n default
   when: get_ambassador_secret.resources|length == 0

--- a/platforms/corda-ent/configuration/roles/create/certificates/ambassador/nmap/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/create/certificates/ambassador/nmap/tasks/main.yaml
@@ -2,10 +2,16 @@
 # and places them in vault. Certificates are created using openssl
 # This also creates the corresponding Kubernetes secret
 ---
+
+# Set variable for networkmap tls certificate path
+- name: Set variable for networkmap tls certificate path
+  set_fact:
+    nmap_tlscert_path: "{{ network | json_query('orderers[?type==`networkmap`].certificate') | first }}"
+
 # check if the ambassador tls directory exists
 - name: "Check if the ambassador directory exists or not"
   stat:
-    path: "./build/ambassador/{{ org.services.networkmap.name }}"
+    path: "{{ nmap_tlscert_path | dirname }}"
   register: ambassadordir_check
 
 # Create the ambassador directory if it doesn't exist
@@ -14,7 +20,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/check/setup"
   vars:
     check: "ensure_dir"
-    path: "./build/ambassador/{{ org.services.networkmap.name }}"
+    path: "{{ nmap_tlscert_path | dirname }}"
   when: not ambassadordir_check.stat.exists
 
 # Check if the ambassador tls is already created
@@ -34,7 +40,7 @@
   vars:
     vault_output: "{{ ambassador_tls_certs.stdout | from_yaml }}"
     type: "ambassador"
-    cert_path: "./build/ambassador/{{ org.services.networkmap.name }}"
+    cert_path: "{{ nmap_tlscert_path | dirname }}"
   when: ambassador_tls_certs.failed == False
 
 # Check if ambassadortls dir is there
@@ -46,7 +52,7 @@
 # Generates the openssl file for domain
 - name: Generate openssl conf file
   shell: |
-    cd ./build/ambassador/{{ org.services.networkmap.name }}
+    cd {{ nmap_tlscert_path | dirname }}
     cat <<EOF >openssl{{ org.services.networkmap.name }}.conf
     [dn]
     CN={{ domain_name }}
@@ -77,20 +83,20 @@
 # Check if the rootca.jks is already present or not
 - name: Check if rootca.jks is present
   stat:
-    path: "./build/ambassador/{{ org.services.networkmap.name }}/rootca.jks"
+    path: "{{ nmap_tlscert_path | dirname }}/rootca.jks"
   register: check_rootcajks
 
 # Store the rootca.jks in build folder if it doesn't exist
 - name: Store the keystore in a file
   copy:
     content: "{{ subordinateca.stdout | b64decode }}"
-    dest: "./build/ambassador/{{ org.services.networkmap.name }}/rootca.jks"
+    dest: "{{ nmap_tlscert_path | dirname }}/rootca.jks"
   when: not check_rootcajks.stat.exists and ambassador_tls_certs.failed == True
 
 # Create ambassador certificates
 - name: Create ambassador certificates
   shell: |
-    cd ./build/ambassador/{{ org.services.networkmap.name }}
+    cd {{ nmap_tlscert_path | dirname }}
     keytool -importkeystore -srckeystore rootca.jks -destkeystore rootca.p12 -deststoretype PKCS12 -srcalias subordinateca -deststorepass password -srcstorepass password
     keytool -export -alias subordinateca -keystore rootca.jks -rfc -file rootca.pem -storepass password
     openssl pkcs12 -in rootca.p12  -nodes -nocerts -out key.pem -passin pass:'password'
@@ -102,7 +108,7 @@
 # Store the ambassador certificates into the vault
 - name: Store the ambassador certs to vault
   shell: |
-    vault kv put secret/{{ org.name | lower }}/{{ org.services.networkmap.name }}/tlscerts tlscacerts="$(cat ./build/ambassador/{{ org.services.networkmap.name }}/ambassador.pem | base64)" tlskey="$(cat ./build/ambassador/{{ org.services.networkmap.name }}/ambassador.key | base64)"
+    vault kv put secret/{{ org.name | lower }}/{{ org.services.networkmap.name }}/tlscerts tlscacerts="$(cat {{ nmap_tlscert_path | dirname }}/ambassador.pem | base64)" tlskey="$(cat {{ nmap_tlscert_path | dirname }}/ambassador.key | base64)"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -121,5 +127,5 @@
 # Create the ambassador secret if it doesn't exist
 - name: Create the ambassador credentials
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} kubectl create secret tls {{ org.services.networkmap.name }}-ambassador-certs --cert="./build/ambassador/{{ org.services.networkmap.name }}/ambassador.pem" --key="./build/ambassador/{{ org.services.networkmap.name }}/ambassador.key" -n default
+    KUBECONFIG={{ org.k8s.config_file }} kubectl create secret tls {{ org.services.networkmap.name }}-ambassador-certs --cert="{{ nmap_tlscert_path | dirname }}/ambassador.pem" --key="{{ nmap_tlscert_path | dirname }}/ambassador.key" -n default
   when: get_ambassador_secret.resources|length == 0

--- a/platforms/corda-ent/configuration/roles/helm_component/templates/create_signer.tpl
+++ b/platforms/corda-ent/configuration/roles/helm_component/templates/create_signer.tpl
@@ -20,7 +20,7 @@ spec:
       imagePullSecret: regcred
       initContainerName: index.docker.io/hyperledgerlabs/alpine-utils:1.0
     storage:
-      name: cenmsc
+      name: cordaentsc
     dockerImageSigner:
       name: corda/enterprise-signer
       tag: 1.2-zulu-openjdk8u242

--- a/platforms/corda-ent/configuration/roles/helm_component/templates/db.tpl
+++ b/platforms/corda-ent/configuration/roles/helm_component/templates/db.tpl
@@ -20,11 +20,11 @@ spec:
       containerName: {{ container_name }}
       imagePullSecret: {{ image_pull_secret }}
     resources:
-      limits: 512Mi
-      requests: 512Mi
+      limits: 128Mi
+      requests: 128Mi
     storage:
       name: {{ storageclass }}
-      memory: 512Mi
+      memory: 128Mi
     service:
       type: NodePort
       tcp:

--- a/platforms/corda-ent/configuration/roles/setup/bridge/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/bridge/tasks/main.yaml
@@ -49,7 +49,7 @@
     auth_path: "cordaent{{ org.name | lower }}"
     vault_serviceaccountname: "vault-auth"
     vault_cert_secret_prefix: "secret/{{ org.name | lower }}"
-    storageclass: cenmsc
+    storageclass: cordaentsc
     float_address: "{{ peer.firewall.float.name | lower }}.{{ org.name | lower }}-ent"
     float_port: "{{ peer.firewall.float.port }}"
     float_subject: "{{ peer.firewall.float.subject }}"

--- a/platforms/corda-ent/configuration/roles/setup/float/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/float/tasks/main.yaml
@@ -24,7 +24,7 @@
     auth_path: "cordaent{{ org.name | lower }}"
     vault_serviceaccountname: "vault-auth"
     vault_cert_secret_prefix: "secret/{{ org.name | lower }}"
-    storageclass: cenmsc
+    storageclass: cordaentsc
     float_address: "{{ peer.firewall.float.name | lower }}.{{ org.name | lower }}-ent"
     float_port: "{{ peer.firewall.float.port }}"
     bridge_subject: "{{ peer.firewall.bridge.subject }}"

--- a/platforms/corda-ent/configuration/roles/setup/idman/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/idman/tasks/main.yaml
@@ -1,5 +1,6 @@
 # This role creates the the value file for idman chart and pushes it to the git repository
 
+# Waitin for the signer pod to come up
 - name: "Waiting for signer pod to come up"
   include_role:
     name: "{{ playbook_dir }}/../../shared/configuration/roles/check/helm_component"
@@ -10,6 +11,11 @@
     kubernetes: "{{ org.k8s }}"
     label_selectors:
       - app = {{ component_name }}
+
+# Create ambassador certificates for idman
+- name: Create idman ambassador certificates
+  include_role:
+    name: create/certificates/ambassador/idman
 
 # This task will loop over the network.yaml to fetch the cenm details
 - name: Create value file for idman
@@ -25,7 +31,7 @@
     git_url: "{{ org.gitops.git_ssh }}"
     git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ org.services.idman.name }}"
-    storageclass: "cenmsc"
+    storageclass: "cordaentsc"
     init_container_name: "index.docker.io/hyperledgerlabs/alpine-utils:1.0"
     image_pull_secret: "regcred"
     idman_image_name: corda/enterprise-identitymanager

--- a/platforms/corda-ent/configuration/roles/setup/nmap/tasks/main.yml
+++ b/platforms/corda-ent/configuration/roles/setup/nmap/tasks/main.yml
@@ -2,6 +2,17 @@
 # This role creates the value file for nmap
 ##############################################################################################
 
+# Create ambassador certificates for networkmap
+- name: Create networkmap ambassador certificates
+  include_role:
+    name: create/certificates/ambassador/nmap
+
+# ----------------------------------------------------------------------   
+# Create value file for notary-initial-registration 
+- name: Create value file for notary registration job
+  include_role:
+    name: setup/notary-initial-registration
+
 # Wait for the notary initial registration job to get complete
 - name: "waiting for notary initial registration job to get complete"
   include_role:
@@ -28,7 +39,7 @@
     git_url: "{{ org.gitops.git_ssh }}"
     git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ org.services.networkmap.name | lower }}"
-    storageclass: "cenmsc"
+    storageclass: "cordaentsc"
     init_container_name: "index.docker.io/hyperledgerlabs/alpine-utils:1.0"
     image_pull_secret: "regcred"
     corda_service_version: cenm-networkmap-{{ org.version }}

--- a/platforms/corda-ent/configuration/roles/setup/node_registration/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/node_registration/tasks/main.yaml
@@ -31,7 +31,7 @@
     git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ peer.name | lower }}"
     image_pull_secret: "regcred"
-    storageclass: "cenmsc"
+    storageclass: "cordaentsc"
     container_name: "index.docker.io/hyperledgerlabs/h2:2018"
     tcp_port: "{{ peer.dbtcp.port }}"
     tcp_targetport: "{{ peer.dbtcp.targetPort }}"

--- a/platforms/corda-ent/configuration/roles/setup/notary/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/notary/tasks/main.yaml
@@ -14,6 +14,11 @@
     label_selectors:
       - app = {{ component_name }}
 
+# Create notary ambassador certificates
+- name: Create ambassador certficates for notary
+  include_role:
+    name: create/certificates/ambassador/notary
+
 # Create deployment file for CENM notary service db
 - name: "Create db for notary"
   include_role:
@@ -29,7 +34,7 @@
     git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ org.services.notary.name | lower }}"
     image_pull_secret: "regcred"
-    storageclass: "cenmsc"
+    storageclass: "cordaentsc"
     container_name: "index.docker.io/hyperledgerlabs/h2:2018"
     tcp_port: "{{ org.services.notary.dbtcp.port }}"
     tcp_targetport: "{{ org.services.notary.dbtcp.targetPort }}"
@@ -53,7 +58,7 @@
     git_url: "{{ org.gitops.git_ssh }}"
     git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ org.services.notary.name }}"
-    storageclass: "cenmsc"
+    storageclass: "cordaentsc"
     init_container_name: "index.docker.io/hyperledgerlabs/alpine-utils:1.0"
     image_pull_secret: "regcred"
     vault_addr: "{{ org.vault.url }}"

--- a/platforms/corda-ent/configuration/roles/setup/tlscerts/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/tlscerts/tasks/main.yaml
@@ -1,46 +1,7 @@
-# This role pulls the idman & networkmap certs from the vault of CENM and pushes it to the vault of all other organizations
-
-- name: Set idman & networkmap info in variables
-  set_fact:
-    idman_name: "{{ network | json_query('orderers[?type==`idman`].name') | first }}"
-    idman_tlscert_path: "{{ network | json_query('orderers[?type==`idman`].certificate') | first }}"
-    networkmap_name: "{{ network | json_query('orderers[?type==`networkmap`].name') | first }}"
-    networkmap_tlscert_path: "{{ network | json_query('orderers[?type==`networkmap`].certificate') | first }}"
-
-# Check if the idman tls certificate is already present in the vault or not
-- name: Check if the idman tls certificate is already present in the vault or not
-  shell: |
-    vault read -field=idman.crt secret/{{ org.name }}/certs/{{ idman_name }}
-  environment:
-    VAULT_ADDR: "{{ org.vault.url }}"
-    VAULT_TOKEN: "{{ org.vault.root_token }}"
-  register: vault_idman_tlscert
-  ignore_errors: yes
-
-# This task copies the idman tls certificate to each org vault
-- name: Copy the idman tls certificate to each org vault
-  shell: |
-    vault kv put secret/{{ org.name }}/certs/{{ idman_name }} idman.crt="$(cat {{ idman_tlscert_path }} | base64 )"
-  environment:
-    VAULT_ADDR: "{{ org.vault.url }}"
-    VAULT_TOKEN: "{{ org.vault.root_token }}"
-  when: vault_idman_tlscert.failed == True
-
-# Check if the networkmap tls certificate is already present in the vault or not
-- name: Check if the networkmap tls certificate is already present in the vault or not
-  shell: |
-    vault read -field=networkmap.crt secret/{{ org.name }}/certs/{{ networkmap_name }}
-  environment:
-    VAULT_ADDR: "{{ org.vault.url }}"
-    VAULT_TOKEN: "{{ org.vault.root_token }}"
-  register: vault_networkmap_tlscert
-  ignore_errors: yes
-
-# This task copies the networkmap tls certificate to each org vault
-- name: Copy the networkmap tls certificate to each org vault
-  shell: |
-    vault kv put secret/{{ org.name }}/certs/{{ networkmap_name }} networkmap.crt="$(cat {{ networkmap_tlscert_path }} | base64 )"
-  environment:
-    VAULT_ADDR: "{{ org.vault.url }}"
-    VAULT_TOKEN: "{{ org.vault.root_token }}"
-  when: vault_networkmap_tlscert.failed == True
+# This role calls for pushing tlscerts to vault for each node
+---
+- name: Push tls certficates to vault
+  include_tasks: nested_main.yaml
+  loop: "{{ org.services.peers }}"
+  loop_control:
+    loop_var: peer

--- a/platforms/corda-ent/configuration/roles/setup/tlscerts/tasks/nested_main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/tlscerts/tasks/nested_main.yaml
@@ -1,0 +1,46 @@
+# This role pulls the idman & networkmap certs from the vault of CENM and pushes it to the vault of all other organizations
+
+- name: Set idman & networkmap info in variables
+  set_fact:
+    idman_name: "{{ network | json_query('orderers[?type==`idman`].name') | first }}"
+    idman_tlscert_path: "{{ network | json_query('orderers[?type==`idman`].certificate') | first }}"
+    networkmap_name: "{{ network | json_query('orderers[?type==`networkmap`].name') | first }}"
+    networkmap_tlscert_path: "{{ network | json_query('orderers[?type==`networkmap`].certificate') | first }}"
+
+# Check if the idman tls certificate is already present in the vault or not
+- name: Check if the idman tls certificate is already present in the vault or not
+  shell: |
+    vault read -field=idman.crt secret/{{ peer.name }}/certs/{{ idman_name }}
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+  register: vault_idman_tlscert
+  ignore_errors: yes
+
+# This task copies the idman tls certificate to each peer vault
+- name: Copy the idman tls certificate to each peer vault
+  shell: |
+    vault kv put secret/{{ peer.name }}/certs/{{ idman_name }} idman.crt="$(cat {{ idman_tlscert_path }} | base64 )"
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+  when: vault_idman_tlscert.failed == True
+
+# Check if the networkmap tls certificate is already present in the vault or not
+- name: Check if the networkmap tls certificate is already present in the vault or not
+  shell: |
+    vault read -field=networkmap.crt secret/{{ peer.name }}/certs/{{ networkmap_name }}
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+  register: vault_networkmap_tlscert
+  ignore_errors: yes
+
+# This task copies the networkmap tls certificate to each peer vault
+- name: Copy the networkmap tls certificate to each peer vault
+  shell: |
+    vault kv put secret/{{ peer.name }}/certs/{{ networkmap_name }} networkmap.crt="$(cat {{ networkmap_tlscert_path }} | base64 )"
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+  when: vault_networkmap_tlscert.failed == True


### PR DESCRIPTION
Signed-off-by: jagpreetsinghsasan <jagpreet.singh.sasan@accenture.com>

**Changelog**
- Add feature to create the tls certificate of cenm services from the path mentioned in network.yaml
- Fix large memory size for resources such as db
- Updated code to move the tls certificate creation tasks within the corresponding CENM service creation role itself to have distinctive roles in network.yaml

 

**Reviewed by**
@suvajit-sarkar 

 

**Linked issue**
#972 
