### PR TITLE
[ Corda-Ent ] Update Signer & Idman, cleanup

### DIFF
--- a/platforms/corda-ent/charts/idman/files/idman.conf
+++ b/platforms/corda-ent/charts/idman/files/idman.conf
@@ -1,4 +1,4 @@
-address = "0.0.0.0:{{ .Values.service.port }}"
+address = "0.0.0.0:{{ .Values.service.external.port }}"
 database {
     driverClassName = "{{ .Values.database.driverClassName }}"
     url = "{{ .Values.database.url }}"
@@ -11,7 +11,7 @@ workflows = {
         type = ISSUANCE
         updateInterval = 10000
         enmListener = {
-            port = {{ .Values.serviceInternal.port }}
+            port = {{ .Values.service.internal.port }}
             reconnect = true
             ssl = {
                 keyStore = {
@@ -33,7 +33,7 @@ workflows = {
         crlCacheTimeout = 900000 # every 15 minutes
         crlFiles = ["./DATA/crl-files/tls.crl", "./DATA/crl-files/root.crl", "./DATA/crl-files/subordinate.crl"]
         enmListener = {
-            port = {{ .Values.serviceRevocation.port }}
+            port = {{ .Values.service.revocation.port }}
             reconnect = true
             ssl = {
                 keyStore = {
@@ -52,7 +52,7 @@ workflows = {
     }
 }
 shell = {
-    sshdPort = "{{ .Values.shell.sshdPort }}"
-    user = "{{ .Values.shell.user }}"
-    password = "{{ .Values.shell.password }}"
+    sshdPort = "{{ .Values.service.shell.sshdPort }}"
+    user = "{{ .Values.service.shell.user }}"
+    password = "{{ .Values.service.shell.password }}"
 }

--- a/platforms/corda-ent/charts/idman/files/run.sh
+++ b/platforms/corda-ent/charts/idman/files/run.sh
@@ -1,24 +1,24 @@
 #!/bin/sh
 
 # main run
-if [ -f {{ .Values.jarPath }}/identitymanager.jar ]
+if [ -f {{ .Values.config.jarPath }}/identitymanager.jar ]
 then
-    sha256sum {{ .Values.jarPath }}/identitymanager.jar 
+    sha256sum {{ .Values.config.jarPath }}/identitymanager.jar 
     cat etc/idman.conf
     echo
     echo "CENM: starting Identity Manager process ..."
     echo
-    java -Xmx{{ .Values.cordaJarMx }}G -jar {{ .Values.jarPath }}/identitymanager.jar -f {{ .Values.configPath }}/idman.conf
+    java -Xmx{{ .Values.config.cordaJar.memorySize }}{{ .Values.config.cordaJar.unit }} -jar {{ .Values.config.jarPath }}/identitymanager.jar -f {{ .Values.config.configPath }}/idman.conf
     EXIT_CODE=${?}
 else
-    echo "Missing Identity Manager jar file in {{ .Values.jarPath }} folder:"
-    ls -al {{ .Values.jarPath }}
+    echo "Missing Identity Manager jar file in {{ .Values.config.jarPath }} folder:"
+    ls -al {{ .Values.config.jarPath }}
     EXIT_CODE=110
 fi
 
 if [ "${EXIT_CODE}" -ne "0" ]
 then
-    HOW_LONG={{ .Values.sleepTimeAfterError }}
+    HOW_LONG={{ .Values.config.sleepTimeAfterError }}
     echo
     echo "exit code: ${EXIT_CODE} (error)"
     echo "Going to sleep for requested ${HOW_LONG} seconds to let you login and investigate."

--- a/platforms/corda-ent/charts/idman/templates/deployment.yaml
+++ b/platforms/corda-ent/charts/idman/templates/deployment.yaml
@@ -4,9 +4,9 @@ kind: Deployment
 metadata:
   name: {{ .Values.nodeName }}
   namespace: {{ .Values.metadata.namespace }}
-  {{- if .Values.deployment.annotations }}
+  {{- if .Values.config.deployment.annotations }}
   annotations:
-{{ toYaml .Values.deployment.annotations | indent 8 }}
+{{ toYaml .Values.config.deployment.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.config.replicas }}
   selector:
     matchLabels:
       app: {{ .Values.nodeName }}
@@ -27,49 +27,26 @@ spec:
         app.kubernetes.io/name: {{ .Values.nodeName }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      serviceAccountName: {{ $.Values.vault.serviceAccountName }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-      initContainers:
-      - name: config
-        image: "{{ required "idman[config]: missing value for .Values.dockerImage.name" .Values.dockerImage.name }}:{{ required "idman[config]: missing value for .Values.dockerImage.tag" .Values.dockerImage.tag }}"
-        imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
-        env:
-          - name: ACCEPT_LICENSE
-            value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
-        command: ["/bin/bash", "-c"]
-        args:
-        - |-
-          cp CM/run.sh bin/
-          cp CM/idman.conf etc/
-          chmod +x bin/*
-          echo "config setup done"
-        volumeMounts:
-        - name: idman-etc
-          mountPath: /opt/corda/etc
-        - name: idman-conf
-          mountPath: /opt/corda/CM
-        resources:
-          requests:
-            memory: {{ .Values.cordaJarMx }}G
-          limits:
-            memory: {{ add .Values.cordaJarMx 2 }}G          
+      initContainers:      
       - name: init-certificates
-        image: {{ .Values.image.initContainerName }}
-        imagePullPolicy: Always
+        image: "{{ required "idman[config]: missing value for .Values.image.initContainerName" .Values.image.initContainerName }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: VAULT_ADDR
             value: {{ $.Values.vault.address }}
           - name: KUBERNETES_AUTH_PATH
-            value: {{ $.Values.vault.authpath }}
+            value: {{ $.Values.vault.authPath }}
           - name: VAULT_APP_ROLE
             value: {{ $.Values.vault.role }}
           - name: BASE_DIR
-            value: {{ $.Values.volume.baseDir }}
+            value: {{ $.Values.config.volume.baseDir }}
           - name: CERTS_SECRET_PREFIX
-            value: {{ .Values.vault.certsecretprefix }}
+            value: {{ .Values.vault.certSecretPrefix }}
           - name: MOUNT_PATH
             value: "/DATA"       
         command: ["sh", "-c"]
@@ -83,12 +60,12 @@ spec:
                 fi
               }
 
-              # setting up env to get secrets from vault
-              echo "Getting secrets from Vault Server"
+              # Setting up the environment to get secrets/certificates from Vault
+              echo "Getting certificates/secrets from Vault Server"
               KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
               VAULT_TOKEN=$(curl -sS --request POST ${VAULT_ADDR}/v1/auth/${KUBERNETES_AUTH_PATH}/login -H "Content-Type: application/json" -d '{"role":"vault-role","jwt":"'"${KUBE_SA_TOKEN}"'"}' | jq -r 'if .errors then . else .auth.client_token end')
               validateVaultResponse 'vault login token' "${VAULT_TOKEN}"
-              echo "logged into vault"
+              echo "Logged into Vault"
               # Creating dirs for storing certificates
               mkdir -p ${MOUNT_PATH}/idman;
               mkdir -p ${MOUNT_PATH}/root;
@@ -96,67 +73,65 @@ spec:
 
               # Fetching ssl-idman certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.healthCheck.readinessThreshold }} ]
               do
                   # get keystores from vault to see if certificates are created and put in vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.nodeName }}/certs | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.healthCheck.readinessCheckInterval }}
                   else
                     idm_ssl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-identity-manager-keys.jks"]')
                     echo "${idm_ssl}" | base64 -d > ${MOUNT_PATH}/idman/corda-ssl-identity-manager-keys.jks
-                    echo "Successfully got ssl idman certifcates"
+                    echo "Successfully got SSL Idman certifcates"
                     break
                   fi 
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthcheck.readinessthreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.healthCheck.readinessThreshold }} ]
               then
                 # printing number of trial done before giving up
-                echo "$COUNTER"
-                echo "ssl idman certificates might not have been put in vault.  Giving up!!!"
+                echo "Idman SSL Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
               echo "Done"
 
               # Fetching corda-ssl-trust-store certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.healthCheck.readinessThreshold }} ]
               do
                   # get keystores from vault to see if certificates are created and put in vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/root/certs | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.healthCheck.readinessCheckInterval }}
                   else
                     root_ssl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-trust-store.jks"]')
                     echo "${root_ssl}" | base64 -d > ${MOUNT_PATH}/root/corda-ssl-trust-store.jks
-                    echo "Successfully got root ssl certifcates"
+                    echo "Successfully got Root SSL certifcates"
                     break
                   fi 
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthcheck.readinessthreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.healthCheck.readinessThreshold }} ]
               then
                 # printing number of trial done before giving up
-                echo "$COUNTER"
-                echo "root ssl certificates might not have been put in vault. Giving up!!!"
+                echo "Root SSL Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
               echo "Done"
 
-              # Fetching crl certificates from vault
+              # Fetching CRL certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.healthCheck.readinessThreshold }} ]
               do
-                  # get crls from vault to see if certificates are created and put in vault
+                  # Get CRLs from vault to see if certificates are created, and have been put in Vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ .Values.nodeName }}/crls | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.healthCheck.readinessCheckInterval }}
                   else
                     tls_crl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tls.crl"]')
                     echo "${tls_crl}" | base64 -d > ${MOUNT_PATH}/crl-files/tls.crl
@@ -167,17 +142,16 @@ spec:
                     subordinate_crl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["subordinate.crl"]')
                     echo "${subordinate_crl}" | base64 -d > ${MOUNT_PATH}/crl-files/subordinate.crl
 
-                    echo "Successfully got crl certifcates"
+                    echo "Successfully got CRL Certifcates"
                     break
                   fi 
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthcheck.readinessthreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.healthCheck.readinessThreshold }} ]
               then
                 # printing number of trial done before giving up
-                echo "$COUNTER"
-                echo "crl certificates might not have been put in vault. Giving up!!!"
+                echo "CRL Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
               echo "Done"
@@ -186,8 +160,8 @@ spec:
           mountPath: /DATA            
       containers:
       - name: idman
-        image: "{{ required "idman[main]: missing value for .Values.dockerImage.name" .Values.dockerImage.name }}:{{ required "idman[main]: missing value for .Values.dockerImage.tag" .Values.dockerImage.tag }}"
-        imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
+        image: "{{ required "idman[idman]: missing value for .Values.image.idmanContainerName" .Values.image.idmanContainerName }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: ACCEPT_LICENSE
             value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
@@ -195,14 +169,14 @@ spec:
         args:
         - |-
           cp CM/run.sh bin/
+          cp CM/idman.conf etc/
           chmod +x bin/*
           bin/run.sh
         volumeMounts:
         - name: idman-etc
           mountPath: /opt/corda/etc
         - name: idman-conf
-          mountPath: /opt/corda/CM/run.sh
-          subPath: run.sh
+          mountPath: /opt/corda/CM
         - name: idman-logs
           mountPath: /opt/corda/logs
         - name: idman-h2
@@ -211,12 +185,12 @@ spec:
           mountPath: /opt/corda/DATA
         resources:
           requests:
-            memory: {{ .Values.cordaJarMx }}G
+            memory: {{ .Values.config.cordaJar.resources.requests}}
           limits:
-            memory: {{ add .Values.cordaJarMx 2 }}G
+            memory: {{ .Values.config.cordaJar.resources.limits}}
       - name: logs
-        image: "{{ required "idman[logs]: missing value for .Values.dockerImage.name" .Values.dockerImage.name }}:{{ required "idman[logs]: missing value for .Values.dockerImage.tag" .Values.dockerImage.tag }}"
-        imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
+        image: "{{ required "idman[logs]: missing value for .Values.image.idmanContainerName" .Values.image.idmanContainerName }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ACCEPT_LICENSE
           value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
@@ -231,7 +205,7 @@ spec:
         - name: idman-logs
           mountPath: /opt/corda/logs
       imagePullSecrets:
-      - name: {{ .Values.dockerImage.imagePullSecret }}
+      - name: {{ .Values.image.imagePullSecret }}
       volumes:
         - name: idman-conf
           configMap:

--- a/platforms/corda-ent/charts/idman/templates/deployment.yaml
+++ b/platforms/corda-ent/charts/idman/templates/deployment.yaml
@@ -73,13 +73,13 @@ spec:
 
               # Fetching ssl-idman certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthCheck.readinessThreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do
-                  # get keystores from vault to see if certificates are created and put in vault
+                  # Get keystores from Vault, to see if certificates are created and have been put in Vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.nodeName }}/certs | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthCheck.readinessCheckInterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                     idm_ssl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-identity-manager-keys.jks"]')
                     echo "${idm_ssl}" | base64 -d > ${MOUNT_PATH}/idman/corda-ssl-identity-manager-keys.jks
@@ -89,9 +89,8 @@ spec:
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthCheck.readinessThreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
-                # printing number of trial done before giving up
                 echo "Idman SSL Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
@@ -99,13 +98,13 @@ spec:
 
               # Fetching corda-ssl-trust-store certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthCheck.readinessThreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do
-                  # get keystores from vault to see if certificates are created and put in vault
+                  # Get keystores from Vault, to see if certificates are created and have been put in Vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/root/certs | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthCheck.readinessCheckInterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                     root_ssl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-trust-store.jks"]')
                     echo "${root_ssl}" | base64 -d > ${MOUNT_PATH}/root/corda-ssl-trust-store.jks
@@ -115,9 +114,8 @@ spec:
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthCheck.readinessThreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
-                # printing number of trial done before giving up
                 echo "Root SSL Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
@@ -125,13 +123,13 @@ spec:
 
               # Fetching CRL certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthCheck.readinessThreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do
                   # Get CRLs from vault to see if certificates are created, and have been put in Vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ .Values.nodeName }}/crls | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthCheck.readinessCheckInterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                     tls_crl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tls.crl"]')
                     echo "${tls_crl}" | base64 -d > ${MOUNT_PATH}/crl-files/tls.crl
@@ -148,9 +146,8 @@ spec:
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthCheck.readinessThreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
-                # printing number of trial done before giving up
                 echo "CRL Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
@@ -185,9 +182,9 @@ spec:
           mountPath: /opt/corda/DATA
         resources:
           requests:
-            memory: {{ .Values.config.cordaJar.resources.requests}}
+            memory: {{ .Values.config.pod.resources.requests}}
           limits:
-            memory: {{ .Values.config.cordaJar.resources.limits}}
+            memory: {{ .Values.config.pod.resources.limits}}
       - name: logs
         image: "{{ required "idman[logs]: missing value for .Values.image.idmanContainerName" .Values.image.idmanContainerName }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/platforms/corda-ent/charts/idman/templates/pvc.yaml
+++ b/platforms/corda-ent/charts/idman/templates/pvc.yaml
@@ -4,9 +4,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.nodeName }}-pvc-logs
   namespace: {{ .Values.metadata.namespace }}
-    {{- if .Values.pvc.annotations }}
+    {{- if .Values.config.pvc.annotations }}
   annotations:
-{{ toYaml .Values.pvc.annotations | indent 8 }}
+{{ toYaml .Values.config.pvc.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}-pvc-logs
@@ -19,7 +19,7 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 64Mi
+      storage: {{ .Values.storage.memory }}
 
 ---
 apiVersion: v1
@@ -27,9 +27,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.nodeName }}-pvc-h2
   namespace: {{ .Values.metadata.namespace }}
-  {{- if .Values.pvc.annotations }}
+  {{- if .Values.config.pvc.annotations }}
   annotations:
-{{ toYaml .Values.pvc.annotations | indent 8 }}
+{{ toYaml .Values.config.pvc.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}-pvc-h2
@@ -42,4 +42,5 @@ spec:
   storageClassName: {{ .Values.storage.name }}
   resources:
     requests:
-      storage: 64Mi
+      storage: {{ .Values.storage.memory }}
+ 

--- a/platforms/corda-ent/charts/idman/templates/service.yaml
+++ b/platforms/corda-ent/charts/idman/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
       name: {{ .Values.nodeName }}-https
       prefix: /
       host: {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}:8443
-      service: {{ .Values.nodeName }}.{{ .Values.metadata.namespace }}:{{ .Values.service.port }}
+      service: {{ .Values.nodeName }}.{{ .Values.metadata.namespace }}:{{ .Values.service.external.port }}
       tls: false
       ---
       apiVersion: ambassador/v1
@@ -31,27 +31,27 @@ metadata:
 spec:
   selector:
     app: {{ .Values.nodeName }}
-# we need healthCheckNodePort set to get rid of logs pollution
-{{- if (.Values.healthCheckNodePort) }}
-  healthCheckNodePort: {{ .Values.healthCheckNodePort }}
+# we need Health Check node port set to get rid of logs pollution
+{{- if (.Values.healthCheck.nodePort) }}
+  healthCheckNodePort: {{ .Values.healthCheck.nodePort }}
 {{- end }}
   ports:
-    - port: {{ .Values.serviceInternal.port }}
-      targetPort: {{ .Values.serviceInternal.port }}
+    - port: {{ .Values.service.internal.port }}
+      targetPort: {{ .Values.service.internal.port }}
       protocol: TCP
       name: issuance
-    - port: {{ .Values.serviceRevocation.port }}
-      targetPort: {{ .Values.serviceRevocation.port }}
+    - port: {{ .Values.service.revocation.port }}
+      targetPort: {{ .Values.service.revocation.port }}
       protocol: TCP
       name: revocation
-    - port: {{ .Values.shell.sshdPort }}
-      targetPort: {{ .Values.shell.sshdPort }}
+    - port: {{ .Values.service.shell.sshdPort }}
+      targetPort: {{ .Values.service.shell.sshdPort }}
       protocol: TCP
-      {{- if .Values.shell.nodePort }}
-      nodePort: {{ .Values.shell.nodePort }}
+      {{- if .Values.service.shell.nodePort }}
+      nodePort: {{ .Values.service.shell.nodePort }}
       {{- end }}
       name: ssh
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+    - port: {{ .Values.service.external.port }}
+      targetPort: {{ .Values.service.external.port }}
       protocol: TCP
       name: main

--- a/platforms/corda-ent/charts/idman/values.yaml
+++ b/platforms/corda-ent/charts/idman/values.yaml
@@ -72,6 +72,15 @@ vault:
   # Provide the vault path where the certificates are stored
   # Eg. certsecretprefix: secret/cenm-org-name
   certSecretPrefix:
+<<<<<<< Updated upstream
+=======
+  # The amount of times to retry fetching from/writing to Vault before giving up.
+  # Eg. retries: 10
+  retries:
+  # The amount of time in seconds to wait after an error occurs when fetching from/writing to Vault.
+  # Eg. sleepTimeAfterError: 15  
+  sleepTimeAfterError:
+>>>>>>> Stashed changes
  
 #############################################################
 #                    Idman Configuration                    #
@@ -184,12 +193,6 @@ config:
 
 # Values    
 healthCheck:
-  # Provide the interval in seconds you want to iterate till db to be ready
-  # Eg. readinessCheckinterval: 10
-  readinessCheckInterval: 
-  # Provide the threshold till you want to check if specified db up and running
-  # Eg. readinessThreshold: 15
-  readinessThreshold:
   # Health Check node port set to get rid of logs pollution
   # Eg. nodePort: 0
   nodePort: 

--- a/platforms/corda-ent/charts/idman/values.yaml
+++ b/platforms/corda-ent/charts/idman/values.yaml
@@ -1,67 +1,60 @@
-# Default values for Identity Manager service.
+# Default values for Identity Manager (Idman) service.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-deployment:
-  annotations: {}
-
+#############################################################
+#                   Basic Configuration                     #
+#############################################################
 # Provide the name of the node
 # Eg. nodeName: idman
 nodeName:
 
-# This section contains the Enterprise-Corda node metadata.
+# This section contains the Corda Enterprise Idman metadata.
 metadata:
-  # Provide the namespace for the Corda node.
+  # Provide the namespace for the Corda Enterprise Idman.
   # Eg. namespace: cenm
   namespace:
-  # Provide the labels to the Corda node.
+  # Provide any additional labels for the Corda Enterprise Idman.
   labels:
 
-pvc:
-  #   annotations:
-  #     key: "value"
-  annotations: {}
-
-# This section contains the storage information.
+# Provide information regarding the Docker images used.
+image:
+  # Provide the alpine utils image, which is used for all init-containers of deployments/jobs.
+  # NOTE: The alpine image used is the base alpine image with CURL installed.
+  # Eg. initContainerName: hyperledgerlabs/alpine-utils:1.0
+  initContainerName:
+  # Provide the image for the main Idman container.
+  # Eg. idmanContainerName: corda/enterprise-identitymanager:1.2-zulu-openjdk8u242
+  idmanContainerName:
+  # Provide the docker-registry secret created and stored in kubernetes cluster as a secret.
+  # Eg. imagePullSecret: regcred
+  imagePullSecret: 
+  # Pull policy to be used for the Docker image
+  # Eg. pullPolicy: Always
+  pullPolicy: 
+  
+# This section contains the storage information, used for the Persistent Volume Claims (PVC).
 storage:
   # Provide the name of the storageclass.
   # NOTE: Make sure that the storageclass exist prior to this deployment as
   # this chart doesn't create the storageclass.
   # Eg. name: cenm
   name:
+  # Provide the memory size for the storage class.
+  # Eg. memory: 64Mi
+  memory:
 
-# Provide the number of replicas for your pods
-# Eg. replicas: 1
-replicas:
-
-# Provide image for init container
-image:
-  # Provide the alpine utils image.
-  # NOTE: The alpine image used is the base alpine image with CURL installed.
-  # Eg. initContainerName: hyperledgerlabs/alpine-utils:1.0
-  initContainerName:
-  # Provide the docker-registry secret created and stored in kubernetes cluster as a secret.
-  # Eg. imagePullSecret: regcred
-  imagepullsecret:
-
-# Provide image for idman container
-dockerImage:
-  # EX. name: corda/enterprise-identitymanager
-  name: 
-  # Ex tag: 1.2-zulu-openjdk8u242
-  tag: 
-  # Ex. pullPolicy: Always
-  pullPolicy: 
-  # EX. imagePullSecret: cenm-registry
-  imagePullSecret: 
-
-# required parameter
-# Accept license should be YES.
+# Required parameter to start any .jar files
+# Eg. acceptLicense: YES 
 acceptLicense: YES
 
-# This section contains the vault related information.
-# NOTE: Make sure that the vault is already unsealed, intialized and configured to
-# use the Kubernetes service account token based authentication.
+#############################################################
+#               HashiCorp Vault Configuration               #
+#############################################################
+# NOTE: Make sure that the vault is already unsealed, intialized and configured to 
+# use Kubernetes service account token based authentication. 
+# For more info, see https://www.vaultproject.io/docs/auth/kubernetes
+
 vault:
   # Provide the vault address
   # Eg. address: http://vault.example.com:8200
@@ -71,84 +64,132 @@ vault:
   role:
   # Provide the authpath configured to be used.
   # Eg. authpath: entcordacenm
-  authpath:
+  authPath:
   # Provide the service account name autheticated to vault.
   # NOTE: Make sure that the service account is already created and autheticated to use the vault.
   # Eg. serviceaccountname: vault-auth
-  serviceaccountname:
-  # Provide the vault path where the  certificates are stored
+  serviceAccountName:
+  # Provide the vault path where the certificates are stored
   # Eg. certsecretprefix: secret/cenm-org-name
-  certsecretprefix:
+  certSecretPrefix:
  
+#############################################################
+#                    Idman Configuration                    #
+#############################################################
 
-# Provide volume related specifications
-volume:
- # Ex baseDir: /opt/corda
-  baseDir: 
-
-# idman service 
 service:
-  # Ex. port: 10000
-  port: 
+  # Idman 'main' service
+  external: 
+    # Eg. port: 10000
+    port: 
+  # Internal service, inside the K8s cluster
+  internal:
+    # Eg. port: 5052
+    port: 
+  revocation:
+    # Eg. port: 5053
+    port: 
+  # Provide the service details for setting up Shell access to the service.
+  shell:
+    # Te port to use for the SSH service
+    # Eg. sshdPort: 2222
+    sshdPort: 
+    # SSH username
+    # Eg. user: idman
+    user: 
+    # SSH password
+    # Eg. password:"idmanP
+    password:
 
-serviceInternal:
-  # internal port inside cluster
-  # Ex. port: 5052
-  port: 
-
-serviceRevocation:
-  # Revocation port inside cluster
-  # Ex port: 5053
-  port: 
-
-# ssh service related configuration
-shell:
-  # Ex. sshdPort: 2222
-  sshdPort: 
-  # ssh username
-  # Ex. user: idman
-  user: 
-  # ssh password
-  # Ex. idmanP
-  password:
-
+#############################################################
+#                Database Options and Configuration         #
+#############################################################
 # Database configuration
 database:
-  # Ex. driverClassName: "org.h2.Driver"
+  # Java class name to use for the database
+  # Eg. driverClassName: "org.h2.Driver"
   driverClassName:
-  # Ex. url: "jdbc:h2:file:./h2/identity-manager-persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=0;AUTO_SERVER_PORT=0"
+  # The DB connection URL 
+  # Eg. url: "jdbc:h2:file:./h2/identity-manager-persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=0;AUTO_SERVER_PORT=0"
   url: 
-  # Ex. user: "example-db-user"
-  user: 
-  # Ex. password: "example-db-password"
+  # DB user
+  # Eg. user: "example-db-user"
+  user:
+  # DB password 
+  # Eg. password: "example-db-password"
   password: 
-  # Ex. runMigration: "true"
+  # Migrations of database can be run as part of the startup of Idman, if set to true. 
+  # If set to false, it will be run prior to setting up the Idman.
+  # Eg. runMigration: "true"
   runMigration: 
 
-# Specify the maximum size of the memory allocation pool
-# cordaJarMx: 1
-cordaJarMx: 
+#############################################################
+#                       Settings                            #
+#############################################################
+config:
+  # Provide volume related specifications
+  volume:
+    # Eg. baseDir: /opt/corda
+    baseDir: 
 
-# healthCheckNodePort set to get rid of logs pollution
-# Ex. healthCheckNodePort: 0
-healthCheckNodePort: 
+  # Provide the path where the CENM Idman .jar-file is stored
+  # Eg. jarPath: bin
+  jarPath: 
 
-# where is CENM service jar file stored
-# Ex. bin
-jarPath: 
+  # Provide the path where the CENM Service configuration files are stored
+  # Eg. configPath: etc
+  configPath: 
 
-# where is CENM service configuration file stored
-# Ex. etc
-configPath: 
+  # Provide any extra annotations for the PVCs
+  pvc:
+    #   annotations:
+    #     key: "value"
+    annotations: {}
 
-# Sleep time after any error encountered in starting idman
-# Ex. 120
-sleepTimeAfterError:
+  # Provide any extra annotations for the deployment
+  deployment:
+    #   annotations:
+    #     key: "value"
+    annotations: {}
 
-healthcheck:
-  #Provide the interval in seconds you want to iterate till db to be ready
-  #Eg. readinesscheckinterval: 10
-  readinesscheckinterval: 
-  #Provide the threshold till you want to check if specified db up and running
-  #Eg. readinessthreshold: 15
-  readinessthreshold:
+  # Specify the maximum size of the memory allocation pool
+  cordaJar:
+    # Provide the memory size.
+    # Eg. memorySize: 4096 (if using kilobytes)
+    # Eg. memorySize: 512 (if using megabytes)
+    # Eg. memorySize: 1 (if using gigabytes) 
+    memorySize:
+    # Provide the unit of greatness for the size, one of three options:
+    # - k or K for kilobytes
+    # - m or M for megabytes
+    # - g or G for gigabytes
+    # Eg. unit: M 
+    unit:
+    # Set limits of .jar  
+    resources:
+      # Provide the limit memory for node
+      # Eg. limits: 512M
+      limits:
+      # Provide the requests memory for node
+      # Eg. requests: 550M
+      requests: 
+
+  # Provide the number of replicas for your pods
+  # Eg. replicas: 1
+  replicas:
+
+  # Sleep time in seconds, occurs after any error is encountered in start-up
+  # Eg. 120
+  sleepTimeAfterError:
+
+# Values    
+healthCheck:
+  # Provide the interval in seconds you want to iterate till db to be ready
+  # Eg. readinessCheckinterval: 10
+  readinessCheckInterval: 
+  # Provide the threshold till you want to check if specified db up and running
+  # Eg. readinessThreshold: 15
+  readinessThreshold:
+  # Health Check node port set to get rid of logs pollution
+  # Eg. nodePort: 0
+  nodePort: 

--- a/platforms/corda-ent/charts/node/values.yaml
+++ b/platforms/corda-ent/charts/node/values.yaml
@@ -50,7 +50,7 @@ storage:
 acceptLicense: YES
 
 #############################################################################################
-#                 This section contains the vault related information.                      #                               
+#               This section contains information related to HashiCorp Vault.               #                               
 #############################################################################################
 # NOTE: Make sure that the vault is already unsealed, intialized and configured to 
 # use Kubernetes service account token based authentication.

--- a/platforms/corda-ent/charts/notary/templates/deployment.yaml
+++ b/platforms/corda-ent/charts/notary/templates/deployment.yaml
@@ -254,7 +254,7 @@ spec:
         - name: notary-logs
           mountPath: /opt/corda/logs
       imagePullSecrets:
-      - name: {{ .Values.image.imagepullSecret }}
+      - name: {{ .Values.image.imagePullSecret }}
       volumes:
       - name: notary-conf
         configMap:

--- a/platforms/corda-ent/charts/notary/values.yaml
+++ b/platforms/corda-ent/charts/notary/values.yaml
@@ -64,7 +64,7 @@ image:
   initContainerName:
   # Provide the docker-registry secret created and stored in kubernetes cluster as a secret.
   # Eg. imagePullSecret: regcred
-  imagepullsecret:
+  imagePullSecret:
 
 # Specify the maximum size of the memory allocation pool
 # cordaJarMx: 3

--- a/platforms/corda-ent/charts/signer/files/signer.conf
+++ b/platforms/corda-ent/charts/signer/files/signer.conf
@@ -87,7 +87,7 @@ signers = {
         type = CSR
         signingKeyAlias = "cordaidentitymanagerca"
         serviceLocationAlias = "identity-manager"
-        crlDistributionPoint = "https://{{ required "Public IP address required (add --set serviceLocations.identityManager.publicIp=x.x.x.x to your helm command)" .Values.serviceLocations.identityManager.publicIp }}:{{ .Values.serviceLocations.identityManager.publicPort }}/certificate-revocation-list/doorman"
+        crlDistributionPoint = "https://{{ .Values.serviceLocations.identityManager.publicIp }}:{{ .Values.serviceLocations.identityManager.publicPort }}/certificate-revocation-list/doorman"
         validDays = 7300 # 20 year certificate expiry
         schedule {
             interval = {{ .Values.signers.CSR.schedule.interval }}
@@ -97,7 +97,7 @@ signers = {
         type = CRL
         signingKeyAlias = "cordaidentitymanagerca"
         serviceLocationAlias = "revocation"
-        crlDistributionPoint = "https://{{ required "Public IP address required (add --set serviceLocations.identityManager.publicIp=x.x.x.x to your helm command)" .Values.serviceLocations.identityManager.publicIp }}:{{ .Values.serviceLocations.identityManager.publicPort }}/certificate-revocation-list/doorman"
+        crlDistributionPoint = "https://{{ .Values.serviceLocations.identityManager.publicIp }}:{{ .Values.serviceLocations.identityManager.publicPort }}/certificate-revocation-list/doorman"
         # updatePeriod = 86400000 # 1 day CRL expiry
         updatePeriod = 604800000 # 1 week CRL expiry
         schedule {

--- a/platforms/corda-ent/charts/signer/files/signer.conf
+++ b/platforms/corda-ent/charts/signer/files/signer.conf
@@ -1,7 +1,7 @@
 shell = {
-    sshdPort = {{ .Values.serviceSsh.port }}
-    user = "{{ .Values.shell.user }}"
-    password = "{{ .Values.shell.password }}"
+    sshdPort = {{ .Values.service.ssh.port }}
+    user = "{{ .Values.service.shell.user }}"
+    password = "{{ .Values.service.shell.password }}"
 }
 
 #############################################
@@ -87,7 +87,7 @@ signers = {
         type = CSR
         signingKeyAlias = "cordaidentitymanagerca"
         serviceLocationAlias = "identity-manager"
-        crlDistributionPoint = "https://{{ required "Public IP address required (add --set idmanPublicIP=x.x.x.x to your helm command)" .Values.idmanPublicIP }}:{{ .Values.idmanPort }}/certificate-revocation-list/doorman"
+        crlDistributionPoint = "https://{{ required "Public IP address required (add --set serviceLocations.identityManager.publicIp=x.x.x.x to your helm command)" .Values.serviceLocations.identityManager.publicIp }}:{{ .Values.serviceLocations.identityManager.publicPort }}/certificate-revocation-list/doorman"
         validDays = 7300 # 20 year certificate expiry
         schedule {
             interval = {{ .Values.signers.CSR.schedule.interval }}
@@ -97,7 +97,7 @@ signers = {
         type = CRL
         signingKeyAlias = "cordaidentitymanagerca"
         serviceLocationAlias = "revocation"
-        crlDistributionPoint = "https://{{ required "Public IP address required (add --set idmanPublicIP=x.x.x.x to your helm command)" .Values.idmanPublicIP }}:{{ .Values.idmanPort }}/certificate-revocation-list/doorman"
+        crlDistributionPoint = "https://{{ required "Public IP address required (add --set serviceLocations.identityManager.publicIp=x.x.x.x to your helm command)" .Values.serviceLocations.identityManager.publicIp }}:{{ .Values.serviceLocations.identityManager.publicPort }}/certificate-revocation-list/doorman"
         # updatePeriod = 86400000 # 1 day CRL expiry
         updatePeriod = 604800000 # 1 week CRL expiry
         schedule {

--- a/platforms/corda-ent/charts/signer/templates/deployment.yaml
+++ b/platforms/corda-ent/charts/signer/templates/deployment.yaml
@@ -4,9 +4,9 @@ kind: Deployment
 metadata:
   name: {{ .Values.nodeName }}
   namespace: {{ .Values.metadata.namespace }}
-  {{- if .Values.deployment.annotations }}
+  {{- if .Values.config.deployment.annotations }}
   annotations:
-{{ toYaml .Values.deployment.annotations | indent 8 }}
+{{ toYaml .Values.config.deployment.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.config.replicas }}
   selector:
     matchLabels:
       app: {{ .Values.nodeName }}
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/name: {{ .Values.nodeName }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      serviceAccountName: {{ $.Values.vault.serviceAccountName }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -40,9 +40,9 @@ spec:
            - name: VAULT_ADDR
              value: {{ $.Values.vault.address }}
            - name: KUBERNETES_AUTH_PATH
-             value: {{ $.Values.vault.authpath }}
+             value: {{ $.Values.vault.authPath }}
            - name: CERTS_SECRET_PREFIX
-             value: {{ .Values.vault.certsecretprefix }}
+             value: {{ .Values.vault.certSecretPrefix }}
           command: ["sh", "-c"]
           args:
           - |-
@@ -54,32 +54,31 @@ spec:
                  fi
                }
 
-              # setting up env to get secrets from vault
-              echo "Getting secrets from Vault Server"
+              # Setting up the environment to get secrets/certificates from Vault
+              echo "Getting secrets/certificates from Vault server"
               KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
               VAULT_TOKEN=$(curl -sS --request POST ${VAULT_ADDR}/v1/auth/${KUBERNETES_AUTH_PATH}/login -H "Content-Type: application/json" -d '{"role":"vault-role","jwt":"'"${KUBE_SA_TOKEN}"'"}' | jq -r 'if .errors then . else .auth.client_token end')
               validateVaultResponse 'vault login token' "${VAULT_TOKEN}"
-              echo "logged into vault"
+              echo "Logged into Vault"
                
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do
-                  # get keystores from vault to see if certificates are created and put in vault
+                  # Get keystores from Vault, to see if the certificates are created and have been put in Vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.nodeName }}/certs | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                     break
                   fi 
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthcheck.readinessthreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
                 # printing number of trial done before giving up
-                echo "$COUNTER"
-                echo "certificates might not have been put in vault."
+                echo "Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
               echo "Done"      
@@ -90,13 +89,13 @@ spec:
            - name: VAULT_ADDR
              value: {{ $.Values.vault.address }}
            - name: KUBERNETES_AUTH_PATH
-             value: {{ $.Values.vault.authpath }}
+             value: {{ $.Values.vault.authPath }}
            - name: VAULT_APP_ROLE
              value: {{ $.Values.vault.role }}
            - name: BASE_DIR
-             value: {{ $.Values.volume.baseDir }}
+             value: {{ $.Values.config.volume.baseDir }}
            - name: CERTS_SECRET_PREFIX
-             value: {{ .Values.vault.certsecretprefix }}
+             value: {{ .Values.vault.certSecretPrefix }}
            - name: MOUNT_PATH
              value: "/DATA"       
           command: ["sh", "-c"]
@@ -144,20 +143,16 @@ spec:
             mountPath: /DATA
       containers:
       - name: signer
-        image: "{{ required "signer[main]: missing value for .Values.dockerImageSigner.name" .Values.dockerImageSigner.name }}:{{ required "signer[main]: missing value for .Values.dockerImageSigner.tag" .Values.dockerImageSigner.tag }}"
+        image: "{{ required "signer[main]: missing value for .Values.iamage.signerContainerName" .Values.image.signerContainerName }}"
         env:
           - name: ACCEPT_LICENSE
             value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
-        imagePullPolicy: {{ .Values.dockerImageSigner.pullPolicy }}
-        lifecycle:
-          postStart:
-            exec:
-              command: ["/bin/sh", "-c", "touch DATA/PKITOOL-DONE"]
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/bash", "-c"]
         args:
         - |-
           cp CM-FILES/signer.conf etc/signer.conf;
-          java -Xmx{{ .Values.cordaJarMx }}G -jar {{ .Values.jarPath }}/signer.jar --config-file {{ .Values.configPath }}/signer.conf
+          java -Xmx{{ .Values.config.cordaJar.memorySize }}{{ .Values.config.cordaJar.unit }} -jar {{ .Values.config.jarPath }}/signer.jar --config-file {{ .Values.config.configPath }}/signer.conf
         volumeMounts:
         - name: signer-conf
           mountPath: /opt/corda/CM-FILES/signer.conf
@@ -170,15 +165,15 @@ spec:
           mountPath: /opt/corda/DATA
         resources:
           requests:
-            memory: {{ .Values.cordaJarMx }}G
+            memory: {{ .Values.config.cordaJar.resources.requests }}
           limits:
-            memory: {{ add .Values.cordaJarMx 2 }}G
+            memory: {{ .Values.config.cordaJar.resources.limits }}
       - name: logs
-        image: "{{ required "signer[logs]: missing value for .Values.dockerImageSigner.name" .Values.dockerImageSigner.name }}:{{ required "signer[logs]: missing value for .Values.dockerImageSigner.tag" .Values.dockerImageSigner.tag }}"
+        image: "{{ required "signer[main]: missing value for .Values.iamage.signerContainerName" .Values.image.signerContainerName }}"
         env:
         - name: ACCEPT_LICENSE
           value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
-        imagePullPolicy: {{ .Values.dockerImageSigner.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/bash", "-c"]
         args:
         - |-

--- a/platforms/corda-ent/charts/signer/templates/deployment.yaml
+++ b/platforms/corda-ent/charts/signer/templates/deployment.yaml
@@ -77,7 +77,6 @@ spec:
 
               if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
-                # printing number of trial done before giving up
                 echo "Certificates might not have been put in Vault. Giving up after $COUNTER tries!"
                 exit 1
               fi
@@ -165,9 +164,9 @@ spec:
           mountPath: /opt/corda/DATA
         resources:
           requests:
-            memory: {{ .Values.config.cordaJar.resources.requests }}
+            memory: {{ .Values.config.pod.resources.requests }}
           limits:
-            memory: {{ .Values.config.cordaJar.resources.limits }}
+            memory: {{ .Values.config.pod.resources.limits }}
       - name: logs
         image: "{{ required "signer[main]: missing value for .Values.iamage.signerContainerName" .Values.image.signerContainerName }}"
         env:

--- a/platforms/corda-ent/charts/signer/templates/service.yaml
+++ b/platforms/corda-ent/charts/signer/templates/service.yaml
@@ -13,15 +13,14 @@ spec:
   selector:
     app: {{ .Values.nodeName }}
 # we need Local policy and healthCheckNodePort set to get rid of logs pollution
-{{- if (.Values.healthCheckNodePort) }}
-  healthCheckNodePort: {{ .Values.healthCheckNodePort }}
+{{- if (.Values.healthCheck.nodePort) }}
+  healthCheckNodePort: {{ .Values.healthCheck.nodePort }}
 {{- end }}
-  type: {{ .Values.serviceSsh.type }}
+  type: {{ .Values.service.ssh.type }}
   ports:
-    - port: {{ .Values.serviceSsh.port }}
-      targetPort: {{ .Values.serviceSsh.targetPort }}
+    - port: {{ .Values.service.ssh.port }}
+      targetPort: {{ .Values.service.ssh.targetPort }}
       protocol: TCP
-      {{- if .Values.serviceSsh.nodePort }}
-      nodePort: {{ .Values.serviceSsh.nodePort }}
+      {{- if .Values.service.ssh.nodePort }}
+      nodePort: {{ .Values.service.ssh.nodePort }}
       {{- end }}
- 

--- a/platforms/corda-ent/charts/signer/values.yaml
+++ b/platforms/corda-ent/charts/signer/values.yaml
@@ -185,7 +185,9 @@ config:
     # - g or G for gigabytes
     # Eg. unit: M
     unit:
-    # Set limits of .jar  
+  
+  # Set memory limits of pod  
+  pod:  
     resources:
       # Provide the limit memory for node
       # Eg. limits: 512M

--- a/platforms/corda-ent/charts/signer/values.yaml
+++ b/platforms/corda-ent/charts/signer/values.yaml
@@ -1,64 +1,49 @@
----
+# Default values for Signer service.
 # This is a YAML-formatted file.
-#Declare variables to be passed into your templates.
+# Declare variables to be passed into your templates.
 
-deployment:
-  annotations: 
+#############################################################
+#                   Basic Configuration                     #
+#############################################################
 # Provide the name of the node
 # Eg. nodeName: signer
 nodeName:
 
-# This section contains the Enterprise-Corda node metadata.
+# This section contains the Corda Enterprise Signer metadata.
 metadata:
-  # Provide the namespace for the Corda node.
+  # Provide the namespace for the Corda Enterprise Signer.
   # Eg. namespace: cenm
   namespace:
-  # Provide the labels to the Corda node.
+  # Provide any additional labels for the Corda Enterprise Signer.
   labels:
 
-# This section contains the storage information.
-storage:
-  # Provide the name of the storageclass.
-  # NOTE: Make sure that the storageclass exist prior to this deployment as
-  # this chart doesn't create the storageclass.
-  # Eg. name: cenm
-  name:
-
-# Provide the number of replicas for your pods
-# Eg. replicaCount: 1
-replicas:
-
-# Provide image for init container
+# Provide information regarding the Docker images used.
 image:
-  # Provide the alpine utils image.
+  # Provide the alpine utils image, which is used for all init-containers of deployments/jobs.
   # NOTE: The alpine image used is the base alpine image with CURL installed.
   # Eg. initContainerName: hyperledgerlabs/alpine-utils:1.0
   initContainerName:
+  # Provide the image for the main Signer container.
+  # Eg. idmanContainerName: corda/enterprise-signer:1.2-zulu-openjdk8u242
+  signerContainerName:
   # Provide the docker-registry secret created and stored in kubernetes cluster as a secret.
   # Eg. imagePullSecret: regcred
   imagePullSecret:
-
-# Provide image for signer container
-dockerImageSigner:
-  # EX. name: corda/enterprise-signer
-  name:
-  # Ex tag: 1.2-zulu-openjdk8u242
-  tag:
-  # Ex. pullPolicy: Always
+  # Pull policy to be used for the Docker image
+  # Eg. pullPolicy: Always
   pullPolicy:
 
-# required parameter for using Enterprise-Corda
-# Accept license should be YES.
+# Required parameter to start any .jar files
+# e.g. acceptLicense: YES 
 acceptLicense: YES
 
-# Provide volume related specificateions
-volume:
- # Ex baseDir: /opt/corda
-  baseDir:
+#############################################################
+#               HashiCorp Vault Configuration               #
+#############################################################
+# NOTE: Make sure that the vault is already unsealed, intialized and configured to 
+# use Kubernetes service account token based authentication. 
+# For more info, see https://www.vaultproject.io/docs/auth/kubernetes
 
-# This section contains the vault related information.
-# NOTE: Make sure that the vault is already unsealed, intialized and configured to
-# use the Kubernetes service account token based authentication.
 vault:
   # Provide the vault address
   # Eg. address: http://vault.example.com:8200
@@ -68,55 +53,66 @@ vault:
   role:
   # Provide the authpath configured to be used.
   # Eg. authpath: entcordacenm
-  authpath:
+  authPath:
   # Provide the service account name autheticated to vault.
   # NOTE: Make sure that the service account is already created and autheticated to use the vault.
-  # Eg. serviceaccountname: vault-auth
-  serviceaccountname:
+  # Eg. serviceAccountName: vault-auth
+  serviceAccountName:
   # Provide the vault path where the  certificates are stored
   # Eg. certsecretprefix: secret/cenm-org-name/signer/certs
-  certsecretprefix:
+  certSecretPrefix:
+  # The amount of times to retry fetching from/writing to Vault before giving up.
+  # Eg. retries: 10
+  retries:
+  # The amount of time in seconds to wait after an error occurs when fetching from/writing to Vault.
+  # Eg. sleepTimeAfterError: 15  
+  sleepTimeAfterError:
 
-healthcheck:
-  #Provide the interval in seconds you want to iterate after for checking certificates
-  #Eg. readinesscheckinterval: 10
-  readinesscheckinterval:
-  # Provide this to iterate till this to check for the certificates
-  # readinessthreshold: 20
-  readinessthreshold:
+
+#############################################################
+#                  Signer Configuration                     #
+#############################################################
 
 # Provide the service details for setting up ssh
-serviceSsh:
-  # Eg. type: ClusterIP
-  type:
-  # Port where ssh is running Ex. port: 2222
-  port:
-  # target port fot the ssh Ex. port: 2222
-  targetPort:
-  nodePort:
-
-# Provide this for logging into signer using shell
-shell:
-  # Ex. user: signer
-  user:
-  # password: SignerP
-  password:
-
-# required parameter public Ip of idman
-idmanPublicIP:
-
-# port number where idman is available
-idmanPort:
+service:
+  ssh:
+    # The type of the SSH service (among such ClusterIP, NodePort)
+    # Eg. type: ClusterIP
+    type:
+    # The port where the SSH service is running inside the cluster
+    # Eg. port: 2222
+    port:
+    # The port where the SSH service will be mapped to, to be accessed outside of the cluster.
+    # Eg. targetPort: 2222
+    targetPort:
+    # If filled, will set the SSH service to type NodePort.
+    # Eg. nodePort: 2223
+    nodePort:
+  # Provide the service details for setting up Shell access to the service.
+  shell:
+    # SSH username
+    # Eg. user: signer
+    user:
+    # SSH password
+    # Eg. password: signerP
+    password:
 
 # provide the other cenm services details
 serviceLocations:
  # Provide the idman service address
   identityManager:
-    # Ex. host: idman.namespace
+    # The internal hostname for the Idman service, inside the K8s cluster
+    # Eg. host: idman.namespace
     host:
-    # Port at which idman service is accessible
-    # Ex. port: 5052
+    # The public IP of the Idman service, accessible outside of the K8s cluster
+    # Eg. publicIp: idman.external-url-suffix.com
+    publicIp:
+    # Port at which idman service is accessible, inside the K8s cluster
+    # Eg. port: 5052
     port:
+    # Public port at which the Idman service is accessible outside the K8s cluster
+    # Eg. publicPort: 8443
+    publicPort:
   # networkmap service details
   networkMap:
     # Ex host: networkmap.namespace
@@ -131,38 +127,78 @@ serviceLocations:
 # Provide signers variables that will go to the template file
 # Like the time interval for checking different tasks
 signers:
-  # For checking certificate signing request schedule
+  # For checking Certificate Signing Request (CSR) schedule
   CSR:
     schedule:
-      # Ex interval: 1m
+      # Eg. interval: 1m
       interval:
-  # For checking certificate revocation list schedule
+  # For checking Certificate Revocation List (CRL) schedule
   CRL:
     schedule:
-      # Ex interval: 1d
+      # Eg. interval: 1d
       interval:
+  # For checking with NetworkMap (NMS)
   NetworkMap:
-    # schedule for checking with nms
     schedule:
-      # Ex interval: 1d
+      # Eg. interval: 1d
       interval:
   # For checking network parameters interval
   NetworkParameters:
     schedule:
-      # Ex interval: 1m
+      # Eg. interval: 1m
       interval:
 
 
-# Provide the JVM for jar
-# cordaJarMx: 1
-cordaJarMx:
+#############################################################
+#                       Settings                            #
+#############################################################
+# Provide volume related specifications
+config:
+  volume:
+  # Eg. baseDir: /opt/corda
+    baseDir:
 
-healthCheckNodePort:
+  # Provide the path where the CENM Signer .jar-file is stored
+  # Eg. jarPath: bin
+  jarPath:
 
-# where is CENM service jar file stored
-# Ex. jarPath: bin
-jarPath:
+  # Provide the path where the CENM Service configuration files are stored
+  # Eg. configPath: etc
+  configPath:
 
-# where is CENM service configuration file stored
-# Ex. configPath: etc
-configPath:
+  # Provide any extra annotations for the deployment
+  deployment:
+    #   annotations:
+    #     key: "value"
+    annotations: {}
+
+  # Provide configuration of the .jar files used in the Node
+  cordaJar:
+    # Provide the memory size.
+    # Eg. memorySize: 4096 (if using kilobytes)
+    # Eg. memorySize: 512 (if using megabytes)
+    # Eg. memorySize: 1 (if using gigabytes) 
+    memorySize:
+    # Provide the unit of greatness for the size, one of three options:
+    # - k or K for kilobytes
+    # - m or M for megabytes
+    # - g or G for gigabytes
+    # Eg. unit: M
+    unit:
+    # Set limits of .jar  
+    resources:
+      # Provide the limit memory for node
+      # Eg. limits: 512M
+      limits:
+      # Provide the requests memory for node
+      # Eg. requests: 550M
+      requests:
+
+  # Provide the number of replicas for your pods
+  # Eg. replicas: 1
+  replicas:
+
+healthCheck:
+  # Health Check node port set to get rid of logs pollution
+  # Eg. nodePort: 0
+  nodePort: 

--- a/platforms/corda-ent/configuration/roles/helm_component/templates/create_signer.tpl
+++ b/platforms/corda-ent/configuration/roles/helm_component/templates/create_signer.tpl
@@ -69,9 +69,9 @@ spec:
       cordaJar:
         memorySize: 512
         unit: M
+      pod:  
         resources:
           limits: 512M
           requests: 512M
       replicas: 1
-    healthCheck:
-      nodePort: 0
+

--- a/platforms/corda-ent/configuration/roles/helm_component/templates/idman.tpl
+++ b/platforms/corda-ent/configuration/roles/helm_component/templates/idman.tpl
@@ -30,6 +30,8 @@ spec:
       role: {{ vault_role }}
       authPath: {{ auth_path }}
       serviceAccountName: {{ vault_serviceaccountname }}
+      retries: 10
+      sleepTimeAfterError: 15
     service:
       external:
         port: {{ idman_port }}
@@ -55,14 +57,11 @@ spec:
       cordaJar:
         memorySize: 512
         unit: M
+      pod:
         resources:
           limits: 512M
           requests: 512M
       replicas: 1
       sleepTimeAfterError: 120
-    healthCheck:
-      readinessCheckInterval: 10
-      readinessThreshold: 15
-      nodePort: 0
     ambassador:
       external_url_suffix: {{ external_url_suffix }}

--- a/platforms/corda-ent/configuration/roles/helm_component/templates/idman.tpl
+++ b/platforms/corda-ent/configuration/roles/helm_component/templates/idman.tpl
@@ -15,49 +15,54 @@ spec:
     nodeName: {{ node_name }}
     metadata:
       namespace: {{ component_ns }}
-    storage:
-      name: {{ storageclass }}
-    replicas: 1
     image:
       initContainerName: {{ init_container_name }}
-      imagepullsecret: {{ image_pull_secret }}
-    dockerImage:
-      name: {{ idman_image_name }}
-      tag: {{ idman_image_tag }}
+      idmanContainerName: {{ idman_image_name }}:{{ idman_image_tag }}
       pullPolicy: Always
       imagePullSecret: {{ image_pull_secret }}
+    storage:
+      name: {{ storageclass }}
+      memory: 64Mi
     acceptLicense: YES
     vault:
       address: {{ vault_addr }}
-      certsecretprefix: {{ vault_cert_secret_prefix }}
+      certSecretPrefix: {{ vault_cert_secret_prefix }}
       role: {{ vault_role }}
-      authpath: {{ auth_path }}
-      serviceaccountname: {{ vault_serviceaccountname }}
-    ambassador:
-      external_url_suffix: {{ external_url_suffix }}
-    volume:
-      baseDir: /opt/corda
+      authPath: {{ auth_path }}
+      serviceAccountName: {{ vault_serviceaccountname }}
     service:
-      port: {{ idman_port }}
-    serviceInternal:
-      port: 5052
-    serviceRevocation:
-      port: 5053
-    shell:
-      sshdPort: 2222
-      user: {{ ssh_username }}
-      password: {{ ssh_password }}
+      external:
+        port: {{ idman_port }}
+      internal:
+        port: 5052
+      revocation:
+        port: 5053
+      shell:
+        sshdPort: 2222
+        user: {{ ssh_username }}
+        password: {{ ssh_password }}
     database:
       driverClassName: "org.h2.Driver"
       url: "jdbc:h2:file:./h2/identity-manager-persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=0;AUTO_SERVER_PORT=0"
       user: {{ db_username }}
       password: {{ db_password }}
       runMigration: "true"
-    cordaJarMx: 1
-    healthCheckNodePort: 0
-    jarPath: bin
-    configPath: etc
-    sleepTimeAfterError: 120
-    healthcheck:
-      readinesscheckinterval: 10
-      readinessthreshold: 15
+    config:
+      volume:
+        baseDir: /opt/corda
+      jarPath: bin
+      configPath: etc
+      cordaJar:
+        memorySize: 512
+        unit: M
+        resources:
+          limits: 512M
+          requests: 512M
+      replicas: 1
+      sleepTimeAfterError: 120
+    healthCheck:
+      readinessCheckInterval: 10
+      readinessThreshold: 15
+      nodePort: 0
+    ambassador:
+      external_url_suffix: {{ external_url_suffix }}

--- a/platforms/corda-ent/configuration/roles/helm_component/templates/notary.tpl
+++ b/platforms/corda-ent/configuration/roles/helm_component/templates/notary.tpl
@@ -25,7 +25,7 @@ spec:
     replicas: 1
     image:
       initContainerName: {{ init_container_name }}
-      imagepullSecret: {{ image_pull_secret }}
+      imagePullSecret: {{ image_pull_secret }}
     cordaJarMx: 3
     devMode: false
     rpcSettingsAddress: "0.0.0.0"

--- a/platforms/corda-ent/configuration/roles/setup/idman/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/idman/tasks/main.yaml
@@ -32,9 +32,9 @@
     git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ org.services.idman.name }}"
     storageclass: "cordaentsc"
-    init_container_name: "index.docker.io/hyperledgerlabs/alpine-utils:1.0"
+    init_container_name: "{{ network.docker.url }}/alpine-utils:1.0"
     image_pull_secret: "regcred"
-    idman_image_name: corda/enterprise-identitymanager
+    idman_image_name: "{{ network.docker.url }}/corda/enterprise-identitymanager"
     idman_image_tag: "1.2-zulu-openjdk8u242"
     vault_addr: "{{ org.vault.url }}"
     vault_cert_secret_prefix: "secret/{{ org.name | lower }}"


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Add Docker images for Signer & Idman to private repository, updated associated roles/templates
- Update  `platforms/shared/configuration/site.yaml` to have option to reset Corda Enterprise network
- Update `values.yaml` for Signer; as well as any mentions of those values in K8s components, templates & Ansible roles
- Update `values.yaml` for Idman; as well as any mentions of those values in K8s components, templates & Ansible roles
- Fixed inconsistencies in the use of `imagePullSecret` from `value.yaml` file vs. hardcoding the secret
- Removed unneeded, hanging pieces of code both in `value.yaml` files & K8s components

**To be reviewed by**
@suvajit-sarkar 

**Linked issue**
#943 
