### PR TITLE
[ Corda-Ent ] Fix cleanup of networkmap

### DIFF
--- a/platforms/corda-ent/charts/idman/values.yaml
+++ b/platforms/corda-ent/charts/idman/values.yaml
@@ -171,14 +171,16 @@ config:
     # - g or G for gigabytes
     # Eg. unit: M 
     unit:
-    # Set limits of .jar  
+
+  # Set memory limits of pod  
+  pod:  
     resources:
       # Provide the limit memory for node
       # Eg. limits: 512M
       limits:
       # Provide the requests memory for node
       # Eg. requests: 550M
-      requests: 
+      requests:
 
   # Provide the number of replicas for your pods
   # Eg. replicas: 1
@@ -187,8 +189,7 @@ config:
   # Sleep time in seconds, occurs after any error is encountered in start-up
   # Eg. 120
   sleepTimeAfterError:
-
-# Values    
+  
 healthCheck:
   # Health Check node port set to get rid of logs pollution
   # Eg. nodePort: 0

--- a/platforms/corda-ent/charts/nmap/files/nmap.conf
+++ b/platforms/corda-ent/charts/nmap/files/nmap.conf
@@ -1,6 +1,6 @@
-address = "0.0.0.0:{{ .Values.service.port }}"
+address = "0.0.0.0:{{ .Values.service.external.port }}"
 pollingInterval = 10000
-checkRevocation = "{{ .Values.checkRevocation }}"
+checkRevocation = "{{ .Values.config.checkRevocation }}"
 database {
     driverClassName = "{{ .Values.database.driverClassName }}"
     url = "{{ .Values.database.url }}"
@@ -10,7 +10,7 @@ database {
 }
 
 enmListener = {
-    port = {{ .Values.serviceInternal.port }}
+    port = {{ .Values.service.internal.port }}
     ssl = {
         keyStore = {
             location = "./DATA/key-stores/corda-ssl-network-map-keys.jks"
@@ -24,8 +24,8 @@ enmListener = {
 }
 
 identityManager = {
-    host = {{ .Values.identityManager.host }}
-    port = {{ .Values.identityManager.port }}
+    host = {{ .Values.serviceLocations.identityManager.host }}
+    port = {{ .Values.serviceLocations.identityManager.port }}
     ssl = {
         keyStore = {
             location = "./DATA/key-stores/corda-ssl-network-map-keys.jks"
@@ -39,8 +39,8 @@ identityManager = {
 }
 
 revocation = {
-    host = {{ .Values.identityManager.host }}
-    port = {{ .Values.revocation.port }}
+    host = {{ .Values.serviceLocations.identityManager.host }}
+    port = {{ .Values.service.revocation.port }}
     ssl = {
         keyStore = {
             location = "./DATA/key-stores/corda-ssl-network-map-keys.jks"
@@ -54,7 +54,7 @@ revocation = {
 }
 
 shell {
-  sshdPort = {{ .Values.shell.sshdPort }}
-  user = "{{ .Values.shell.user }}"
-  password = "{{ .Values.shell.password }}"
+  sshdPort = {{ .Values.service.shell.sshdPort }}
+  user = "{{ .Values.service.shell.user }}"
+  password = "{{ .Values.service.shell.password }}"
 }

--- a/platforms/corda-ent/charts/nmap/files/run.sh
+++ b/platforms/corda-ent/charts/nmap/files/run.sh
@@ -1,24 +1,15 @@
 #!/bin/sh
-{{ if eq .Values.bashDebug true }}
-set -x
-{{ end }}
 
-#
-# main run
-#
-if [ -f {{ .Values.jarPath }}/networkmap.jar ]
+if [ -f {{ .Values.config.jarPath }}/networkmap.jar ]
 then
-{{ if eq .Values.bashDebug true }}
-    sha256sum {{ .Values.jarPath }}/networkmap.jar 
-{{ end }}
     echo
     echo "CENM: starting Networkmap service ..."
     echo
-    cat {{ .Values.configPath }}/nmap.conf
-    java -Xmx{{ .Values.cordaJarMx }}M -jar {{ .Values.jarPath }}/networkmap.jar -f {{ .Values.configPath }}/nmap.conf
+    cat {{ .Values.config.configPath }}/nmap.conf
+    java -Xmx{{ .Values.config.cordaJar.memorySize }}{{ .Values.config.cordaJar.unit }} -jar {{ .Values.config.jarPath }}/networkmap.jar -f {{ .Values.config.configPath }}/nmap.conf
     EXIT_CODE=${?}
 else
-    echo "Missing networkmap jar file in {{ .Values.jarPath }} folder:"
-    ls -al {{ .Values.jarPath }}
+    echo "Missing networkmap jar file in {{ .Values.config.jarPath }} folder:"
+    ls -al {{ .Values.config.jarPath }}
     EXIT_CODE=110
 fi

--- a/platforms/corda-ent/charts/nmap/files/set-network-parameters.sh
+++ b/platforms/corda-ent/charts/nmap/files/set-network-parameters.sh
@@ -1,11 +1,8 @@
 #!/bin/sh
-{{ if eq .Values.bashDebug true }}
-set -x
-{{ end }}
 
 echo "Waiting for notary-nodeinfo/network-parameters-initial.conf ..."
 
-if [ ! -f {{ .Values.configPath }}/network-parameters-initial-set-succesfully ]
+if [ ! -f {{ .Values.config.configPath }}/network-parameters-initial-set-succesfully ]
 then
     until [ -f notary-nodeinfo/network-parameters-initial.conf ]
     do
@@ -15,13 +12,13 @@ fi
 
 echo "Waiting for notary-nodeinfo/network-parameters-initial.conf ... done."
 ls -al notary-nodeinfo/network-parameters-initial.conf
-cp notary-nodeinfo/network-parameters-initial.conf {{ .Values.configPath }}/
-cat {{ .Values.configPath }}/network-parameters-initial.conf
+cp notary-nodeinfo/network-parameters-initial.conf {{ .Values.config.configPath }}/
+cat {{ .Values.config.configPath }}/network-parameters-initial.conf
 
 echo "Setting initial network parameters ..."
-java -jar {{ .Values.jarPath }}/networkmap.jar \
-	-f {{ .Values.configPath }}/nmap.conf \
-	--set-network-parameters {{ .Values.configPath }}/network-parameters-initial.conf \
+java -jar {{ .Values.config.jarPath }}/networkmap.jar \
+	-f {{ .Values.config.configPath }}/nmap.conf \
+	--set-network-parameters {{ .Values.config.configPath }}/network-parameters-initial.conf \
 	--network-truststore DATA/trust-stores/network-root-truststore.jks \
 	--truststore-password password \
 	--root-alias cordarootca
@@ -30,23 +27,22 @@ EXIT_CODE=${?}
 
 if [ "${EXIT_CODE}" -ne "0" ]
 then
-    HOW_LONG={{ .Values.sleepTimeAfterError }}
+    HOW_LONG=120
     echo
     echo "Network Map: setting network parameters failed - exit code: ${EXIT_CODE} (error)"
     echo
     echo "Going to sleep for requested ${HOW_LONG} seconds to let you login and investigate."
     echo
 else
-    HOW_LONG={{ .Values.sleepTime }}
+    HOW_LONG=0
     echo
     echo "Network Map: initial network parameters have been set."
     echo "No errors."
-    echo "Sleeping for requested ${HOW_LONG} seconds before disappearing."
     echo
-    touch {{ .Values.configPath }}/network-parameters-initial-set-succesfully
-    echo "# This is a file with _example_ content needed for updating network parameters" > {{ .Values.configPath }}/network-parameters-update-example.conf
-    cat {{ .Values.configPath }}/network-parameters-initial.conf >> {{ .Values.configPath }}/network-parameters-update-example.conf
-cat << EOF >> {{ .Values.configPath }}/network-parameters-update-example.conf
+    touch {{ .Values.config.configPath }}/network-parameters-initial-set-succesfully
+    echo "# This is a file with _example_ content needed for updating network parameters" > {{ .Values.config.configPath }}/network-parameters-update-example.conf
+    cat {{ .Values.config.configPath }}/network-parameters-initial.conf >> {{ .Values.config.configPath }}/network-parameters-update-example.conf
+cat << EOF >> {{ .Values.config.configPath }}/network-parameters-update-example.conf
 # updateDeadline=\$(date -u +'%Y-%m-%dT%H:%M:%S.%3NZ' -d "+10 minute")
 parametersUpdate {
     description = "Update network parameters settings"

--- a/platforms/corda-ent/charts/nmap/templates/deployment.yaml
+++ b/platforms/corda-ent/charts/nmap/templates/deployment.yaml
@@ -4,9 +4,9 @@ kind: Deployment
 metadata:
   name: {{ .Values.nodeName }}
   namespace: {{ .Values.metadata.namespace }}
-  {{- if .Values.deployment.annotations }}
+  {{- if .Values.config.deployment.annotations }}
   annotations:
-{{ toYaml .Values.deployment.annotations | indent 8 }}
+{{ toYaml .Values.config.deployment.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/name: {{ .Values.nodeName }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      serviceAccountName: {{ $.Values.vault.serviceAccountName }}
       securityContext:
         fsGroup: 1000
       initContainers:
@@ -38,13 +38,13 @@ spec:
           - name: VAULT_ADDR
             value: {{ $.Values.vault.address }}
           - name: KUBERNETES_AUTH_PATH
-            value: {{ $.Values.vault.authpath }}
+            value: {{ $.Values.vault.authPath }}
           - name: VAULT_APP_ROLE
             value: {{ $.Values.vault.role }}
           - name: BASE_DIR
-            value: {{ $.Values.volume.baseDir }}
+            value: {{ $.Values.config.volume.baseDir }}
           - name: CERTS_SECRET_PREFIX
-            value: {{ .Values.vault.certsecretprefix }}
+            value: {{ .Values.vault.certSecretPrefix }}
           - name: MOUNT_PATH
             value: "/DATA"
           - name: NODEINFO_MOUNT_PATH
@@ -74,12 +74,12 @@ spec:
 
               # Getting intitial network parameters from Vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do 
-                LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.notaryName }}/networkparam | jq -r 'if .errors then . else . end')
+                LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.serviceLocations.notary.name }}/nparam | jq -r 'if .errors then . else . end')
                 if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                    initial_param=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["network-parameters-initial"]')
                    echo "${initial_param}" | base64 -d > ${NODEINFO_MOUNT_PATH}/network-parameters-initial.conf
@@ -91,16 +91,15 @@ spec:
 
               # Getting node Info File from Vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do 
-                LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.notaryName }}/nodeInfo | jq -r 'if .errors then . else . end')
+                LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.serviceLocations.notary.name }}/nodeInfo | jq -r 'if .errors then . else . end')
                 if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                   notary_nodeinfo=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["nodeInfoFile"]')
-                  notary_nodeinfo_name=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["nodeInfoName"]')
-                  echo "${notary_nodeinfo}" | base64 -d > ${NODEINFO_MOUNT_PATH}/${notary_nodeinfo_name}
+                  echo "${notary_nodeinfo}" | base64 -d > ${NODEINFO_MOUNT_PATH}/notary_nodeinfo
                   echo "Successfully got node info file"
                   break
                 fi
@@ -109,13 +108,13 @@ spec:
                   
               # Fetching ssl-idman certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do
                   # get keystores from vault to see if certificates are created and put in vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.nodeName }}/certs | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                     idm_ssl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-network-map-keys.jks"]')
                     echo "${idm_ssl}" | base64 -d > ${MOUNT_PATH}/key-stores/corda-ssl-network-map-keys.jks
@@ -125,7 +124,7 @@ spec:
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthcheck.readinessthreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
                 # printing number of trial done before giving up
                 echo "$COUNTER"
@@ -136,13 +135,13 @@ spec:
 
               # Fetching corda-ssl-trust-store certificates from vault
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do
                   # get keystores from vault to see if certificates are created and put in vault
                   LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/root/certs | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                     root_ssl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-trust-store.jks"]')
                     echo "${root_ssl}" | base64 -d > ${MOUNT_PATH}/trust-stores/corda-ssl-trust-store.jks
@@ -156,7 +155,7 @@ spec:
                   COUNTER=`expr "$COUNTER" + 1`
               done
 
-              if [ "$COUNTER" -ge {{ $.Values.healthcheck.readinessthreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
                 # printing number of trial done before giving up
                 echo "$COUNTER"
@@ -168,13 +167,13 @@ spec:
               # Fetching crl certificates from vault
               # TODO: Check if CRL certificates are required for NMS
               COUNTER=1
-              while [ "$COUNTER" -lt {{ $.Values.healthcheck.readinessthreshold }} ]
+              while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
               do
                   # get crls from vault to see if certificates are created and put in vault
-                  LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.idmanName }}/crls | jq -r 'if .errors then . else . end')
+                  LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ $.Values.serviceLocations.identityManager.name }}/crls | jq -r 'if .errors then . else . end')
                   if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
                   then
-                    sleep {{ $.Values.healthcheck.readinesscheckinterval }}
+                    sleep {{ $.Values.vault.sleepTimeAfterError }}
                   else
                     tls_crl=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tls.crl"]')
                     echo "${tls_crl}" | base64 -d > ${MOUNT_PATH}/crl-files/tls.crl
@@ -190,12 +189,12 @@ spec:
                   fi
                   COUNTER=`expr "$COUNTER" + 1`
               done
-              LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ .Values.idmanName }}/tlscerts | jq -r 'if .errors then . else . end')
-              validateVaultResponse "secret (${CERTS_SECRET_PREFIX}/{{ .Values.idmanName }}/tlscerts)" "${LOOKUP_SECRET_RESPONSE}"
+              LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ .Values.serviceLocations.identityManager.name }}/tlscerts | jq -r 'if .errors then . else . end')
+              validateVaultResponse "secret (${CERTS_SECRET_PREFIX}/{{ .Values.serviceLocations.identityManager.name }}/tlscerts)" "${LOOKUP_SECRET_RESPONSE}"
               IDMAN_CERT=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tlscacerts"]')
               echo "${IDMAN_CERT}" | base64 -d > ${MOUNT_PATH}/idman.crt
 
-              if [ "$COUNTER" -ge {{ $.Values.healthcheck.readinessthreshold }} ]
+              if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
               then
                 # printing number of trial done before giving up
                 echo "$COUNTER"
@@ -209,8 +208,8 @@ spec:
         - name: notary-nodeinfo
           mountPath: /notary-nodeinfo
       - name: setnparam
-        image: "{{ required "nmap[setnparam]: missing value for .Values.dockerImage.name" .Values.dockerImage.name }}"
-        imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
+        image: "{{ required "nmap[setnparam]: missing value for .Values.image.nmapContainerName" .Values.image.nmapContainerName }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: ACCEPT_LICENSE
             value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
@@ -220,7 +219,7 @@ spec:
           cp -r CM-FILES/*.conf etc/
           cp -r CM-FILES/*.sh bin/
           chmod +x bin/*
-          if [ ! -f {{ .Values.configPath }}/network-parameters-initial-set-succesfully ]
+          if [ ! -f {{ .Values.config.configPath }}/network-parameters-initial-set-succesfully ]
           then
             echo "Setting network parameters for deployment..."
             bin/set-network-parameters.sh
@@ -246,13 +245,13 @@ spec:
           mountPath: /opt/corda/h2
         resources:
           requests:
-            memory: {{ .Values.cordaJarMx }}M
+            memory: {{ .Values.config.pod.resources.requests }}
           limits:
-            memory: {{ add .Values.cordaJarMx 2 }}M
+            memory: {{ .Values.config.pod.resources.limits }}
       containers:
       - name: main
-        image: "{{ required "nmap[main]: missing value for .Values.dockerImage.name" .Values.dockerImage.name }}"
-        imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
+        image: "{{ required "nmap[main]: missing value for .Values.image.nmapContainerName" .Values.image.nmapContainerName }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: ACCEPT_LICENSE
             value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
@@ -261,7 +260,13 @@ spec:
         - |-
           cp -r CM-FILES/*.sh bin/
           chmod +x bin/*
-          yes | keytool -importcert -file ./DATA/idman.crt -storepass changeit -alias {{ .Values.idmanDomain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts
+          until [ -f {{ .Values.config.configPath }}/network-parameters-initial-set-succesfully ]
+          do
+            sleep 5
+            echo "Waiting for network parameters to be set..."
+          done
+          echo "Network parameters have been set!"
+          yes | keytool -importcert -file ./DATA/idman.crt -storepass changeit -alias {{ .Values.serviceLocations.identityManager.domain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts
           bin/run.sh
         volumeMounts:
         - name: nmap-conf
@@ -282,12 +287,12 @@ spec:
           mountPath: /opt/corda/DATA
         resources:
           requests:
-            memory: {{ .Values.cordaJarMx }}M
+            memory: {{ .Values.config.pod.resources.requests }}
           limits:
-            memory: {{ add .Values.cordaJarMx 2 }}M
+            memory: {{ .Values.config.pod.resources.limits }}
       - name: logs
-        image: "{{ required "nmap[logs]: missing value for .Values.dockerImage.name" .Values.dockerImage.name }}"
-        imagePullPolicy: {{ .Values.dockerImage.pullPolicy }}
+        image: "{{ required "nmap[logs]: missing value for .Values.image.nmapContainerName" .Values.image.nmapContainerName }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: ACCEPT_LICENSE
             value: "{{required "You must accept the license agreement to run this software" .Values.acceptLicense }}"
@@ -302,7 +307,7 @@ spec:
         - name: nmap-logs
           mountPath: /opt/corda/logs
       imagePullSecrets:
-      - name: {{ .Values.image.imagepullsecret }}
+      - name: {{ .Values.image.imagePullSecret }}
       volumes:
         - name: certificates
           emptyDir:

--- a/platforms/corda-ent/charts/nmap/templates/pvc.yaml
+++ b/platforms/corda-ent/charts/nmap/templates/pvc.yaml
@@ -4,9 +4,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.nodeName }}-pvc-logs
   namespace: {{ .Values.metadata.namespace }}
-    {{- if .Values.pvc.annotations }}
+    {{- if .Values.config.pvc.annotations }}
   annotations:
-{{ toYaml .Values.pvc.annotations | indent 8 }}
+{{ toYaml .Values.config.pvc.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}-pvc-logs
@@ -27,9 +27,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.nodeName }}-pvc-h2
   namespace: {{ .Values.metadata.namespace }}
-  {{- if .Values.pvc.annotations }}
+  {{- if .Values.config.pvc.annotations }}
   annotations:
-{{ toYaml .Values.pvc.annotations | indent 8 }}
+{{ toYaml .Values.config.pvc.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}-pvc-h2
@@ -49,9 +49,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.nodeName }}-etc
   namespace: {{ .Values.metadata.namespace }}
-  {{- if .Values.pvc.annotations }}
+  {{- if .Values.config.pvc.annotations }}
   annotations:
-{{ toYaml .Values.pvc.annotations | indent 8 }}
+{{ toYaml .Values.config.pvc.annotations | indent 8 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.nodeName }}-etc

--- a/platforms/corda-ent/charts/nmap/templates/service.yaml
+++ b/platforms/corda-ent/charts/nmap/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
       name: {{ .Values.nodeName }}-https
       prefix: /
       host: {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}:8443
-      service: {{ .Values.nodeName }}.{{ .Values.metadata.namespace }}:{{ .Values.service.port }}
+      service: {{ .Values.nodeName }}.{{ .Values.metadata.namespace }}:{{ .Values.service.external.port }}
       tls: false
       ---
       apiVersion: ambassador/v1
@@ -32,23 +32,23 @@ metadata:
 spec:
   selector:
     app: {{ .Values.nodeName }}
-# we need healthCheckNodePort set to get rid of logs pollution
-{{- if (.Values.healthCheckNodePort) }}
-  healthCheckNodePort: {{ .Values.healthCheckNodePort }}
+# W e need healthCheckNodePort set to get rid of logs pollution
+{{- if (.Values.healthCheck.nodePort) }}
+  healthCheckNodePort: {{ .Values.healthCheck.nodePort }}
 {{- end }}
   ports:
-    - port: {{ .Values.serviceInternal.port }}
-      targetPort: {{ .Values.serviceInternal.port }}
+    - port: {{ .Values.service.internal.port }}
+      targetPort: {{ .Values.service.internal.port }}
       protocol: TCP
       name: http-internal
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+    - port: {{ .Values.service.external.port }}
+      targetPort: {{ .Values.service.external.port }}
       protocol: TCP
       name: http
-    - port: {{ .Values.shell.sshdPort }}
-      targetPort: {{ .Values.shell.sshdPort }}
+    - port: {{ .Values.service.shell.sshdPort }}
+      targetPort: {{ .Values.service.shell.sshdPort }}
       protocol: TCP
-      {{- if .Values.shell.nodePort }}
-      nodePort: {{ .Values.shell.nodePort }}
+      {{- if .Values.service.shell.nodePort }}
+      nodePort: {{ .Values.service.shell.nodePort }}
       {{- end }}
       name: ssh

--- a/platforms/corda-ent/charts/nmap/values.yaml
+++ b/platforms/corda-ent/charts/nmap/values.yaml
@@ -1,135 +1,53 @@
-# Default values for the Networkmap Service.
+# Default values for the Networkmap (nmap) service.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-# For each of the example values, the ` `-quotes are to be removed when filling them in,
-# these are only used to denote the example value.
+
+#############################################################
+#                   Basic Configuration                     #
+#############################################################
 
 # Provide the name of the node
 # e.g. `networkmap`
 nodeName:
 
-# Provide the name of the corresponding notary; this is needed to get the correct node info files from Vault
-# e.g. `notary`
-notaryName:
-
-# Name of idman service
-# idmanName: idmankd
-idmanName: 
-# External domain name of idman service
-idmanDomain: 
-
-
-deployment:
-  annotations: {}
-
-bashDebug:
-
-pvc:
-  #   annotations:
-  #     key: "value"
-  annotations: {}
-
+# This section contains the Corda Enterprise nmap metadata.
 metadata:
-  # Provide the namespace, e.g. `default`
-  namespace: 
+  # Provide the namespace for the Corda Enterprise nmap.
+  # Eg. namespace: cenm
+  namespace:
+  # Provide any additional labels for the Corda Enterprise nmap.
+  labels:
+
+storage:
+  # Provide the name of the storageclass.
+  # NOTE: Make sure that the storageclass exist prior to this deployment as
+  # this chart doesn't create the storageclass.
+  # Eg. name: cenm
+  name:
+  # Provide the memory size for the storage class.
+  # Eg. memory: 64Mi
+  memory:
 
 # Image for the init-containers
 image:
   # Name of the Docker image to use for init-containers, e.g. `index.docker.io/hyperledgerlabs/alpine-utils:1.0`
   initContainerName:
-  # Pull secret to use for the Docker image, e.g. `regcred`
-  imagepullsecret:
-
-dockerImage:
   # Name of the Docker image to use for the main Networkmap Service, e.g. corda/enterprise-networkmap:1.2-zulu-openjdk8u24
-  name:
+  nmapContainerName:
+  # Pull secret to use for the Docker image, e.g. `regcred`
+  imagePullSecret:
   # When to pull the image, e.g. `Always`
   pullPolicy:
 
 # required parameter
-acceptLicense:
+acceptLicense: YES
 
-# required for exposing the service externally
-ambassador:
-  external_url_suffix:
-storage:
-  # Name for the storage to use, e.g. `abcd`
-  name:
-# How many replicas to make of this service, e.g. `1`
-replicas:
-
-service:
-  # # Type of service to use, e.g. `LoadBalancer`
-  # type: LoadBalancer
-  # Port to use for the service, e.g. `10000`
-  port:
-
-serviceInternal:
-  # # Type of service to use, e.g. `LoadBalancer`
-  # type: LoadBalancer
-  # Port to use for the internal service, e.g. `5050`
-  port:
-
-# Values for the ssh session into the Networkmap Service
-shell:
-  # Port to use in sshd service, e.g. `2222`
-  sshdPort:
-  # User for ssh session, e.g. `nmap`
-  user:
-  # Password for ssh session, e.g. `password`
-  password:
-
-# The folder where the JAR file for CENM service is stored, e.g. `bin`
-jarPath:
-
-
-# The folder where the configuration files for CENM service are stored, e.g. `bin`
-configPath:
-
-# Database configuration, for persiting the network information
-database:
-  # Class name for DB driver, e.g. "org.h2.Driver" (use double quotes!)
-  driverClassName:
-  # URL for DB , e.g. "jdbc:h2:file:./h2/networkmap-persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=0;AUTO_SERVER_PORT=0" (use double quotes!)
-  url:
-  # DB user, e.g. "example-db-user" (use double quotes!)
-  user:
-  # DB password, e.g. "example-db-password" (use double quotes!)
-  password:
-  # Whether to run migration, e.g. `true`
-  runMigration:
-
-# Whether the NMS will check the certificate revocation list, e.g. `true`
-checkRevocation: true
-
-# Values for the Identity Manager (idman)
-identityManager:
-  # Host of idman, e.g. `idman.{namespace}`
-  host:
-  # Port of idman, e.g. `5052`
-  port:
-
-# Values for the Revocation check
-revocation:
-  # On which port to check for Revocation, e.g. `5053`
-  port:
-
-# How many seconds to sleep after error, e.g. `120`
-sleepTimeAfterError:
-# How many seconds to sleep after completing setup of service, e.g. `60`
-sleepTime:
-
-# Specifies maximum size, in gigabytes, of memory allocation pool when running JAR files
-cordaJarMx:
-
-# Which port to use for health check, e.g. `0`
-healthCheckNodePort: 0
-
-healthcheck:
-  # Provide the interval in seconds you want to iterate until DB is ready, e.g. `5`
-  readinesscheckinterval:
-  # Provide the threshold till you want to check if specified DB up and running, e.g. `2`
-  readinessthreshold:
+#############################################################
+#               HashiCorp Vault Configuration               #
+#############################################################
+# NOTE: Make sure that the vault is already unsealed, intialized and configured to 
+# use Kubernetes service account token based authentication. 
+# For more info, see https://www.vaultproject.io/docs/auth/kubernetes
 
 # Values for HashiCorp Vault
 vault:
@@ -138,13 +56,148 @@ vault:
   # Which role to use when connecting to vault, e.g. `vault-role`
   role:
   # Authpath created for networkmap, e.g. cordaentcenm
-  authpath: 
+  authPath: 
   # Serviceaccount, eg. vault-auth
-  serviceaccountname: 
+  serviceAccountName: 
   # Prefix to use for secret engine for certificates, e.g. `cenm/certs`
-  certsecretprefix: 
+  certSecretPrefix: 
+  # The amount of times to retry fetching from/writing to Vault before giving up.
+  # Eg. retries: 10
+  retries:
+  # The amount of time in seconds to wait after an error occurs when fetching from/writing to Vault.
+  # Eg. sleepTimeAfterError: 15  
+  sleepTimeAfterError:
+ 
 
-# Provide volume related specifications
-volume:
-  # E.g. baseDir: /opt/corda
-  baseDir:
+#############################################################
+#                    Nmap Configuration                     #
+#############################################################
+
+service:
+  # Nmap 'main' service
+  external:
+    # E.g. port: 10000
+    port:
+  # Internal service, inside the K8s cluster
+  internal:
+    # E.g. port: 5050
+    port:
+  # Values for the Revocation check
+  revocation:
+    # On which port to check for Revocation, e.g. `5053`
+    port:
+  # Values for the ssh session into the Networkmap Service
+  shell:
+    # Port to use in sshd service, e.g. `2222`
+    sshdPort:
+    # User for ssh session, e.g. `nmap`
+    user:
+    # Password for ssh session, e.g. `password`
+    password:
+
+serviceLocations:
+  # Values for the Identity Manager (idman)
+  identityManager:
+    # Name of idman service
+    # E.g. name: idman
+    name: 
+    # External domain name of idman service
+    # E.g. domain: 
+    domain:
+    # Host of idman 
+    # E.g. host: idman.{namespace}
+    host:
+    # Port of idman
+    # E.g. port: 5052
+    port: 
+  # Values for notary service
+  notary:
+    # Name of the notary service
+    # E.g. name: notary
+    name:
+
+#############################################################
+#                Database Options and Configuration         #
+#############################################################
+database:
+  # Java class name to use for the database
+  # Eg. driverClassName: "org.h2.Driver"
+  driverClassName:
+  # The DB connection URL 
+  # Eg. url: "jdbc:h2:file:./h2/identity-manager-persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=0;AUTO_SERVER_PORT=0"
+  url:
+  # DB user
+  # Eg. user: "example-db-user"
+  user:
+  # DB password 
+  # Eg. password: "example-db-password"
+  password:
+  # Migrations of database can be run as part of the startup of nmap, if set to true. 
+  # If set to false, it will be run prior to setting up the nmap.
+  # E.g. runMigration: true
+  runMigration:
+
+#############################################################
+#                       Settings                            #
+#############################################################
+config:
+  # Provide volume related specifications
+  volume:
+    # E.g. baseDir: /opt/corda
+    baseDir:
+
+  # Provide the path where the CENM Idman .jar-file is stored
+  # Eg. jarPath: bin
+  jarPath:
+
+  # Provide the path where the CENM Service configuration files are stored
+  # Eg. configPath: etc
+  configPath:
+  
+  # Provide any extra annotations for the PVCs
+  pvc:
+    #   annotations:
+    #     key: "value"
+    annotations: {}
+
+  # Provide any extra annotations for the deployment
+  deployment:
+    #   annotations:
+    #     key: "value"
+    annotations: {}
+
+  # Specify the maximum size of the memory allocation pool
+  cordaJar:
+    # Provide the memory size.
+    # Eg. memorySize: 4096 (if using kilobytes)
+    # Eg. memorySize: 512 (if using megabytes)
+    # Eg. memorySize: 1 (if using gigabytes) 
+    memorySize:
+    # Provide the unit of greatness for the size, one of three options:
+    # - k or K for kilobytes
+    # - m or M for megabytes
+    # - g or G for gigabytes
+    # Eg. unit: M 
+    unit:
+    
+  # Set memory limits of pod  
+  pod:  
+    resources:
+      # Provide the limit memory for node
+      # Eg. limits: 512M
+      limits:
+      # Provide the requests memory for node
+      # Eg. requests: 550M
+      requests:
+         
+  # Provide the number of replicas for your pods
+  # Eg. replicas: 1
+  replicas:
+  
+  # Whether the NMS will check the certificate revocation list, e.g. `true`
+  checkRevocation: true
+
+healthCheck:
+  # Health Check node port set to get rid of logs pollution
+  # Eg. nodePort: 0
+  nodePort:

--- a/platforms/corda-ent/configuration/roles/helm_component/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/helm_component/tasks/main.yaml
@@ -21,7 +21,8 @@
     src: "{{ helm_templates[type] | default('helm_component.tpl') }}"
     dest: "{{ values_dir }}/{{ name }}/{{ component_name }}.yaml"
   vars:
-    docker_image: "{{ corda_enterprise_image[corda_service_version] }}"
+    docker_image: "{{ docker_images.cenm[corda_service_version] }}"
+    init_image: "{{ docker_images.init_container }}"
     
 ############################################################################################
 # This task tests the value file for syntax errors/ missing values

--- a/platforms/corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
+++ b/platforms/corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
@@ -30,9 +30,6 @@ spec:
       authPath: cordaent{{ org.name | lower }}
       retries: 30
       retryInterval: 10
-    cenmServices:
-      idmanName: {{ org.services.idman.name }}
-      networkmapName: {{ org.services.networkmap.name }}
     service:
       p2pPort: {{ notary_service.p2p.port }}
       rpc:
@@ -47,8 +44,10 @@ spec:
           username: notary
           password: notaryP
     networkServices:
+      idmanName: {{ org.services.idman.name }}
       doormanURL: {{ idman_url }}
       idmanDomain: {{ idman_domain }}
+      networkmapName: {{ org.services.networkmap.name }}
       networkMapURL: {{ networkmap_url }}
       networkMapDomain: {{ networkmap_domain }}
     dataSourceProperties:

--- a/platforms/corda-ent/configuration/roles/helm_component/vars/main.yaml
+++ b/platforms/corda-ent/configuration/roles/helm_component/vars/main.yaml
@@ -10,8 +10,10 @@ helm_templates:
   float: float.tpl
   node_registration: node_registration.tpl
   node: node.tpl
-corda_enterprise_image:
-  cenm-networkmap-1.2: adopblockchaincloud0502.azurecr.io/corda/enterprise-networkmap:1.2-zulu-openjdk8u242
-  cenm-notary-1.2: adopblockchaincloud0502.azurecr.io/corda_image_notary_1.2:latest
-  firewall: adopblockchaincloud0502.azurecr.io/corda_image_firewall_4.4:latest
-  node: adopblockchaincloud0502.azurecr.io/corda_image_ent_4.4:latest
+docker_images:
+  cenm:
+    networkmap-1.2: corda/enterprise-networkmap:1.2-zulu-openjdk8u242
+    notary-1.2: adopblockchaincloud0502.azurecr.io/corda_image_notary_1.2:latest
+    firewall: adopblockchaincloud0502.azurecr.io/corda_image_firewall_4.4:latest
+    node: adopblockchaincloud0502.azurecr.io/corda_image_ent_4.4:latest
+  init_container: alpine-utils:1.0

--- a/platforms/corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
@@ -66,34 +66,15 @@
   include_role:
     name: helm_component
   vars:
-    component_name: "{{ org.name | lower }}nmap"
     type: "nmap"
-    values_dir: "{{playbook_dir}}/../../../{{ org.gitops.release_dir }}"
     name: "{{ org.name | lower }}"
+    component_name: "{{ org.name | lower }}nmap"
     charts_dir: "{{ org.gitops.chart_source }}"
-    notary_name: "{{ org.services.notary.name }}"
-    idman_name: "{{ org.services.idman.name }}"
-    idman_url: "{{ network | json_query('orderers[?type==`idman`].uri') | first }}"
-    idman_domain: "{{ idman_url.split(':')[1] | regex_replace('/', '') }}"
-    git_url: "{{ org.gitops.git_ssh }}"
-    git_branch: "{{ org.gitops.branch }}"
-    node_name: "{{ org.services.networkmap.name | lower }}"
-    storageclass: "cordaentsc"
-    init_container_name: "index.docker.io/hyperledgerlabs/alpine-utils:1.0"
-    image_pull_secret: "regcred"
-    corda_service_version: cenm-networkmap-{{ org.version }}
-    vault_addr: "{{ org.vault.url }}"
-    vault_cert_secret_prefix: "secret/{{ org.name | lower }}"
-    authpath: "cordaent{{ org.name | lower }}"
-    serviceaccountname: "vault-auth"
-    external_url_suffix: "{{ org.external_url_suffix }}"
-    nmap_port: "{{ org.services.networkmap.ports }}"
-    ssh_username: "nmap"
-    ssh_password: "nmapP"
-    db_username: "{{ org.services.networkmap.name }}-db-user"
-    db_password: "{{ org.services.networkmap.name }}-db-password"
+    values_dir: "{{playbook_dir}}/../../../{{ org.gitops.release_dir }}"
+    corda_service_version: networkmap-{{ org.version }}
+    idman_url: "{{ network | json_query('orderers[?type==`idman`].uri') | first }}" # Keep this in ansible role to prevent confusion in template
     helm_lint: "true"
-    
+
 # Push the nmap deployment files to repository
 - name: "Push the created deployment files to repository"
   include_role: 

--- a/platforms/corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
@@ -66,7 +66,7 @@
     idman_domain: "{{ idman_url.split(':')[1] | regex_replace('/', '') }}"    
     networkmap_url: "{{ network | json_query('orderers[?type==`networkmap`].uri') | first }}"
     networkmap_domain: "{{ networkmap_url.split(':')[1] | regex_replace('/', '') }}"
-    corda_service_version: cenm-notary-{{ org.version }}
+    corda_service_version: notary-{{ org.version }}
   when: nodekeystore_result.failed == True
 
 - name: "Push the created deployment files to repository"

--- a/platforms/corda-ent/configuration/roles/setup/notary/tasks/main.yaml
+++ b/platforms/corda-ent/configuration/roles/setup/notary/tasks/main.yaml
@@ -41,7 +41,9 @@
     idman_domain: "{{ idman_url.split(':')[1] | regex_replace('/', '') }}"    
     networkmap_url: "{{ network | json_query('orderers[?type==`networkmap`].uri') | first }}"
     networkmap_domain: "{{ networkmap_url.split(':')[1] | regex_replace('/', '') }}"
-    corda_service_version: cenm-notary-{{ org.version }}
+    corda_service_version: notary-{{ org.version }}
+    p2p_port: "{{ org.services.notary.p2p.port }}"
+    ambassador_p2pPort: "{{ org.services.notary.p2p.ambassador }}"
 
 # Push the notary deployment files to repository
 - name: "Push the created deployment files to repository"


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Fix `pod.resources` in `idman/values.yaml`
- Update `values.yaml` file for networkmap; as well as any mentions of these values in K8s files & Ansible roles
- Clean up `platforms/corda-ent/configuration/roles/helm_component/templates/nmap.tpl` to be in the same order as the `value.yaml` file
- Update `platforms/corda-ent/charts/nmap/templates/deployment.yaml` to add a check to `main` container, to verify that `setnparam` init-container has run
- Cleanup logic of referencing Docker images in `platforms/corda-ent/configuration/roles/helm_component/tasks/main.yaml`; as well as update the variables in `platforms/corda-ent/configuration/roles/helm_component/vars/main.yaml`

**To be reviewed by**
@jagpreetsinghsasan @suvajit-sarkar 

**Linked issue**
#977 
