### PR TITLE
[ Quorum ] Update network charts to Helm 3

### DIFF
--- a/platforms/quorum/charts/node_constellation/Chart.yaml
+++ b/platforms/quorum/charts/node_constellation/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 appVersion: "2.0"
 description: A Helm chart to deploy Quorum nodes with constellation transaction manager
 name: node_constellation

--- a/platforms/quorum/charts/node_constellation/templates/deployment.yaml
+++ b/platforms/quorum/charts/node_constellation/templates/deployment.yaml
@@ -18,7 +18,11 @@ spec:
       app: consortiumchain
       name: {{ .Values.node.name }}
       service.rpc: {{ .Values.node.name }}
-  strategy:
+      app.kubernetes.io/name: {{ .Values.node.name }}
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }} 
+  updateStrategy:
     type: RollingUpdate
   template:
     metadata:
@@ -27,6 +31,10 @@ spec:
         app: consortiumchain
         name: {{ .Values.node.name }}
         service.rpc: {{ .Values.node.name }}
+        app.kubernetes.io/name: {{ .Values.node.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }} 
     spec:
       serviceAccountName: {{ .Values.vault.serviceaccountname }}
       imagePullSecrets:
@@ -41,7 +49,6 @@ spec:
             items:
               - key: genesis.json.base64
                 path: genesis.json.base64
-            
       initContainers:
       - name: certificates-init
         image: {{ .Values.images.alpineutils }}

--- a/platforms/quorum/charts/node_tessera/Chart.yaml
+++ b/platforms/quorum/charts/node_tessera/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 appVersion: "2.0"
 description: A Helm chart to deploy Quorum nodes with tessera transaction manager
 name: node_tessera


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Update the Quorum constellation charts to be compatible with Helm 3
- Majority of the 'general' Quorum changes were already done in issue #892 / PR #1035 
- Revert `apiVersion` of both Tesseract & Constellation to `v1`

**To be reviewed by**
@suvajit-sarkar 

**Linked issue**
#950 
