### PR TITLE
[ Fabric ] Fix reset playbook error

### DIFF
--- a/platforms/hyperledger-fabric/configuration/reset-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/reset-network.yaml
@@ -46,7 +46,6 @@
     # Delete genesis
     - include_role:
         name: "delete/genesis"
-      loop: "{{ network['channels'] }}"
 
     # Delete Gitops file and check-in
     - include_role:


### PR DESCRIPTION
**Changelog**
- Fix `reset-playbook.yaml` error - `delete/genesis` role will not loop over channels anymore 

**To be reviewed by**
@jagpreetsinghsasan 

**Linked issue**
#1028 
