### PR TITLE
[ Fabric ] Add the support of orderer cli in fabric.

### DIFF
--- a/docs/source/architectureref/certificates_path_list_fabric.md
+++ b/docs/source/architectureref/certificates_path_list_fabric.md
@@ -20,6 +20,14 @@ Certificate Paths on Vault for Fabric Network
 | /secret/crypto/ordererOrganizations/`orgname_lowercase`-net/orderers/orderer.`orgname_lowercase`-net/tls/ | ca.crt                              | Certificate |
 | /secret/crypto/ordererOrganizations/`orgname_lowercase`-net/orderers/orderer.`orgname_lowercase`-net/tls/ | server.key                          | Private key |
 | /secret/crypto/ordererOrganizations/`orgname_lowercase`-net/orderers/orderer.`orgname_lowercase`-net/tls/ | server.crt                          | Certificate |
+| /secret/crypto/peerOrganizations/`orgname_lowercase`-net/users/admin/msp/                                 | admincerts                          | Certificate |
+| /secret/crypto/peerOrganizations/`orgname_lowercase`-net/users/admin/msp/                                 | keystore                            | Certificate |
+| /secret/crypto/peerOrganizations/`orgname_lowercase`-net/users/admin/msp/                                 | signcerts                           | Certificate |
+| /secret/crypto/peerOrganizations/`orgname_lowercase`-net/users/admin/msp/                                 | tlscacerts                          | Certificate |
+| /secret/crypto/peerOrganizations/`orgname_lowercase`-net/users/admin/tls/                                 | ca.crt                              | Certificate |
+| /secret/crypto/peerOrganizations/`orgname_lowercase`-net/users/admin/tls/                                 | client.crt                          | Certificate |
+| /secret/crypto/peerOrganizations/`orgname_lowercase`-net/users/admin/tls/                                 | client.key                          | Private Key |
+
 
 -------------------------------
 ### For each peer organization

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/main.yaml
@@ -10,3 +10,23 @@
   loop: "{{ services.orderers }}"
   loop_control:
     loop_var: orderer
+
+# Check admin msp already created
+- name: Check if admin msp already created
+  shell: |
+    vault kv get -field=admincerts secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
+  environment:
+    VAULT_ADDR: "{{ vault.url }}"
+    VAULT_TOKEN: "{{ vault.root_token }}"
+  register: vault_admin_result
+  ignore_errors: yes
+  changed_when: false
+
+- name: Copy organization level certificates for orgs
+  shell: |
+    vault write secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/tls ca.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)" client.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.crt)" client.key="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.key)"
+    vault write secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp admincerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)"
+  environment:
+    VAULT_ADDR: "{{ vault.url }}"
+    VAULT_TOKEN: "{{ vault.root_token }}"
+  when: vault_admin_result.failed == True

--- a/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
@@ -8,11 +8,7 @@
 - name: "Create genesis block"
   shell: |
     cd {{ build_path }}
-    {% if '2.' in network.version %}
-    ./configtxgen -profile {{ genesis.name }} -channelID syschannel  -outputBlock ./channel-artifacts/genesis.block
-    {% else %}
-    ./configtxgen -profile {{ genesis.name }} -outputBlock ./channel-artifacts/genesis.block
-    {% endif %}
+    ./configtxgen -profile {{ genesis.name }} -channelID syschannel -outputBlock ./channel-artifacts/genesis.block
     cat ./channel-artifacts/genesis.block | base64 > ./channel-artifacts/genesis.block.base64
   when: add_new_org == 'false'
   tags:

--- a/platforms/hyperledger-fabric/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -83,6 +83,8 @@
     vault delete secret/crypto/ordererOrganizations/{{ component_name }}/ca
     vault delete secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls
     vault delete secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp
+    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/tls
+    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
     vault delete secret/crypto/ordererOrganizations/{{ component_name }}/ambassador/{{orderer.name}}
     vault delete secret/credentials/{{ component_name }}/ca/{{ org_name }}
   loop: "{{ services.orderers }}"

--- a/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/orderer_cli.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/orderer_cli.tpl
@@ -1,0 +1,28 @@
+metadata:
+  namespace: {{ component_ns }}
+  images:
+    fabrictools: {{ fabrictools_image }}
+    alpineutils: {{ alpine_image }}
+storage:
+  class: {{ storage_class }}
+  size: 256Mi
+vault:
+  role: vault-role
+  address: {{ vault.url }}
+  authpath: {{ component_ns }}-auth
+  adminsecretprefix: secret/crypto/ordererOrganizations/{{ component_ns }}/users/admin
+  orderersecretprefix: secret/crypto/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer_component }}
+  serviceaccountname: vault-auth
+  imagesecretname: regcred
+  tls: false
+peer:
+  name: {{ orderer_name }}
+  localmspid: {{ org.name | lower}}MSP
+  tlsstatus: true
+{% if network.env.proxy == 'none' %}
+  address: {{ orderer_name }}.{{ component_ns }}:7051
+{% else %}
+  address: {{ orderer_address }}
+{% endif %}
+orderer:
+  address: {{ orderer_address }}

--- a/platforms/hyperledger-fabric/configuration/roles/k8_component/vars/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/k8_component/vars/main.yaml
@@ -4,4 +4,4 @@ k8_templates:
   vaultAuth: vault_auth.tpl
   reviewer_rbac: reviewer_rbac.tpl
   existing_peer_cli_job: existing_peer_cli.tpl
- 
+  orderer_cli_job: orderer_cli.tpl


### PR DESCRIPTION
Signed-off-by: lakshyakumar <lakshya.kumar@accenture.com>

**Changelog**
- Add the system channel name while creating the genesis file
- Add the orderer_cli in k8_component/templates/orderer_cli.tpl 
- Add the crypto material of admin of orderer org to the vault and delete it on reset.

 

**Reviewed by**
@jagpreetsinghsasan 

 

**Linked issue**
#1072 
