### PR TITLE
[ Fabric ] Upgrade Fabric code + ref-app to Helm 3

### DIFF
--- a/examples/supplychain-app/charts/fabric-restserver/Chart.yaml
+++ b/examples/supplychain-app/charts/fabric-restserver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for an api server
 name: fabric-restserver
 version: 0.1.0

--- a/examples/supplychain-app/charts/frontend/templates/deployment.yaml
+++ b/examples/supplychain-app/charts/frontend/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       app: {{ .Values.nodeName }}
       app.kubernetes.io/name: {{ .Values.nodeName }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
   strategy:
     type: Recreate
     rollingUpdate: null

--- a/examples/supplychain-app/configuration/roles/helm_component/templates/expressapi-fabric.tpl
+++ b/examples/supplychain-app/configuration/roles/helm_component/templates/expressapi-fabric.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ name }}-expressapi
   namespace: {{ component_ns }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   chart:
     path: {{ component_gitops.chart_source }}/expressapp

--- a/examples/supplychain-app/configuration/roles/helm_component/templates/restserver.tpl
+++ b/examples/supplychain-app/configuration/roles/helm_component/templates/restserver.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ name }}-restserver
   namespace: {{ component_ns }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   chart:
     path: {{ component_gitops.chart_source }}/fabric-restserver

--- a/platforms/hyperledger-fabric/charts/anchorpeer/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/anchorpeer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for updating the anchorpeer details
 name: anchorpeer
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/ca/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/ca/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for CA server
 name: ca
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/ca/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/ca/templates/deployment.yaml
@@ -14,14 +14,17 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: {{ $.Values.server.name }}
       app.kubernetes.io/name: {{ $.Values.server.name }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }} 
   template:
     metadata:
       labels:
         name: {{ $.Values.server.name }}
         app.kubernetes.io/name: {{ $.Values.server.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}  
         app.kubernetes.io/instance: {{ .Release.Name }} 
     spec:
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/catools/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/catools/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for Fabric CA tools
 name: catools
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/catools/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/catools/templates/deployment.yaml
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: {{ .Values.metadata.name }}
   namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Values.metadata.name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/platforms/hyperledger-fabric/charts/create_channel/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/create_channel/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for create channel
 name: create_channel
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/create_channel/templates/create_channel.yaml
+++ b/platforms/hyperledger-fabric/charts/create_channel/templates/create_channel.yaml
@@ -22,6 +22,7 @@ spec:
         app: createchannel-{{ $.Values.channel.name }}
         app.kubernetes.io/name: createchannel-{{ $.Values.channel.name }}
         app.kubernetes.io/instance: {{ .Release.Name }} 
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       restartPolicy: "OnFailure"
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/fabric_cli/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for Fabric Cli
 name: fabric_cli
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/install_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for chaincode installation on a peer
 name: install_chaincode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: installchaincode-{{ $.Values.peer.name }}-{{ $.Values.chaincode.name }}-{{ $.Values.chaincode.version }}
+        app.kubernetes.io/name: installchaincode-{{ $.Values.chaincode.name }}{{ $.Values.chaincode.version }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for chaincode instantiation on a peer
 name: instantiate_chaincode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: instantiatechaincode-{{ $.Values.chaincode.name }}-{{ $.Values.chaincode.version }}
+        app.kubernetes.io/name: instantiatechaincode-{{ $.Values.chaincode.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for chaincode invocation on a peer
 name: invoke_chaincode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: invokechaincode-{{ $.Values.chaincode.name }}-{{ $.Values.chaincode.version }}
+        app.kubernetes.io/name: invokechaincode-{{ $.Values.chaincode.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/join_channel/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for joining the channel
 name: join_channel
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         app: joinchannel-{{ $.Values.peer.name }}-{{ $.Values.channel.name }}
         app.kubernetes.io/name: joinchannel-{{ $.Values.peer.name }}-{{ $.Values.channel.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: "OnFailure"

--- a/platforms/hyperledger-fabric/charts/orderernode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for orderer node
 name: orderernode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/orderernode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     matchLabels:
       app: {{ $.Values.orderer.name }}
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/name: {{ $.Values.orderer.name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
@@ -25,6 +26,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app: {{ $.Values.orderer.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/name: {{ $.Values.orderer.name }}
         app.kubernetes.io/instance: {{ .Release.Name }} 
     spec:    

--- a/platforms/hyperledger-fabric/charts/peernode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for peer node
 name: peernode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
     matchLabels:
       app: {{ $.Values.peer.name }}
       app.kubernetes.io/name: {{ $.Values.peer.name }}
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
       labels:
         app: {{ $.Values.peer.name }}
         app.kubernetes.io/name: {{ $.Values.peer.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:   
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for chaincode upgrade on a peer
 name: upgrade_chaincode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: upgradechaincode-{{ $.Values.peer.name }}-{{ $.Values.chaincode.name }}
+        app.kubernetes.io/name: upgradechaincode-{{ $.Values.chaincode.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/verify_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/verify_chaincode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for chaincode verify a peer
 name: verify_chaincode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/verify_chaincode/templates/verify_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/verify_chaincode/templates/verify_chaincode.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: verifychaincode-{{ $.Values.peer.name }}-{{ $.Values.chaincode.name }}
+        app.kubernetes.io/name: verifychaincode-{{ $.Values.chaincode.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/charts/zkkafka/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/zkkafka/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for zookeeper & kafka
 name: zkkafka
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/zkkafka/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/zkkafka/templates/deployment.yaml
@@ -20,12 +20,16 @@ spec:
     matchLabels:
       app: {{ $.Values.zookeeper.name }}
       app.kubernetes.io/name: {{ $.Values.zookeeper.name }}
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ $.Values.zookeeper.name }}
         app.kubernetes.io/name: {{ $.Values.zookeeper.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       terminationGracePeriodSeconds: 10

--- a/platforms/hyperledger-fabric/configuration/README.md
+++ b/platforms/hyperledger-fabric/configuration/README.md
@@ -68,7 +68,7 @@ We are working on a verification document for Hyperledger Fabric.
     ```
     ansible-playbook add-organization.yaml -e "@/path/to/network-fabric.yaml" -e "add_new_org='true'"
     ```
-    Follow steps in [README](https://github.com/hyperledger-labs/blockchain-automation-framework/docs/source/operations/adding_new_org_fabric.md).
+    Follow steps in [README](https://blockchain-automation-framework.readthedocs.io/en/latest/operations/adding_new_org_fabric.html).
 
     (Above command assumes that network.yaml is present in current directory with org_status tag and new organization details).<br>
 

--- a/platforms/hyperledger-fabric/configuration/add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-organization.yaml
@@ -113,7 +113,8 @@
         minutes: 6
 
     # Create Organization crypto materials for new organization
-    - include_role:
+    - name: "Crypto"
+      include_role:
         name: "create/crypto/peer"
       vars:
         component_name: "{{ item.name | lower}}-net"

--- a/platforms/hyperledger-fabric/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/deploy-network.yaml
@@ -19,7 +19,8 @@
         state: absent
 
     # Create Namespaces and Vault-rbac kubernetes-value files
-    - include_role:
+    - name: Create namespace and Vault auth for each organization
+      include_role:
         name: "create/namespace_vaultauth"
       vars:
         component_name: "{{ item.name | lower }}-net"
@@ -29,7 +30,8 @@
       loop: "{{ network['organizations'] }}"
     
     #Setup Vault-Kubernetes accesses and Regcred for docker registry
-    - include_role: 
+    - name: Setup Vault Kubernetes for each organization
+      include_role: 
         name: "setup/vault_kubernetes"
       vars:
         component_name: "{{ item.name | lower }}-net"
@@ -40,7 +42,8 @@
       loop: "{{ network['organizations'] }}"
 
     # Create Storageclass 
-    - include_role:
+    - name: Create storageclass for each organization
+      include_role:
         name: "create/storageclass"
       vars:
         sc_name: "{{ item.name | lower}}sc"
@@ -50,7 +53,8 @@
       loop: "{{ network['organizations'] }}"
         
     # Create CA Server helm-value files and check-in
-    - include_role:
+    - name: Create CA server for each organization
+      include_role:
         name: "create/ca-server"
       vars:
         component_name: "{{ item.name | lower}}-net"
@@ -67,7 +71,8 @@
       when: item.services.ca is defined
         
     # Create CA Tools helm-value files and check-in
-    - include_role:
+    - name: Create CA tools for each organization
+      include_role:
         name: "create/ca-tools"
       vars:
         component_name: "{{ item.name | lower}}-net"
@@ -82,7 +87,8 @@
       loop: "{{ network['organizations'] }}"
 
     # Create generate_crypto script for each organization
-    - include_role:
+    - name: Create generate_crypto.sh for each organization
+      include_role:
         name: "create/crypto_script"
       vars:
         component_type: "{{ item.type | lower}}"
@@ -96,7 +102,8 @@
         minutes: 6
 
     # Create Orderer crypto materials
-    - include_role:
+    - name: Create crypto materials for each orderer
+      include_role:
         name: "create/crypto/orderer"
       vars:
         component_name: "{{ item.name | lower}}-net"
@@ -111,7 +118,8 @@
       when: item.type == 'orderer'
     
     # Create Organization crypto materials
-    - include_role:
+    - name: Create crypto materials for each peer
+      include_role:
         name: "create/crypto/peer"
       vars:
         component_name: "{{ item.name | lower}}-net"
@@ -128,13 +136,14 @@
     # Creating channel artifacts and putting them in vault
     # This role creates configtx.yaml file as the requirements mentioned in network.yaml
     # which is then consumed by configtxgen tool
-    - include_role:
+    - name: Create configtx.yaml
+      include_role:
         name: "create/configtx"
       vars:
         config_file: "./build/configtx.yaml"
 
     # This role generate genesis block and channeltx
-    - name: "Create channel artifacts"
+    - name: Create channel artifacts for all channels
       include_role:
         name: "create/channel_artifacts"
       vars:
@@ -152,7 +161,8 @@
       loop: "{{ network['channels'] }}"
     
     # This role creates value file for zk-kafka (if kafka consensus is chosen) and orderer
-    - include_role:
+    - name: Create all orderers
+      include_role:
         name: "create/orderers"
       vars:
         build_path: "./build"
@@ -170,7 +180,8 @@
 
     # This role creates the value file for peers of organisations and write couch db credentials
     # to the vault.
-    - include_role:
+    - name: Create all peers
+      include_role:
         name: "create/peers"
       vars:
         build_path: "./build"
@@ -188,7 +199,8 @@
 
     # This role creates the value file for creating channel from creator organization
     # to the vault.
-    - include_role:
+    - name: Create all create-channel jobs
+      include_role:
         name: "create/channels"
       vars:
         build_path: "./build"
@@ -198,7 +210,8 @@
 
     # This role creates the value file for joining channel from each participating peer
     # to the vault.
-    - include_role:
+    - name: Create all join-channel jobs
+      include_role:
         name: "create/channels_join"
       vars:
         build_path: "./build"
@@ -208,7 +221,8 @@
 
     # This role creates the value file for anchor peer update over channel for
     # each organization which is the part of the channel.
-    - include_role:
+    - name: Create all anchor-peer jobs
+      include_role:
         name: "create/anchorpeer"
       vars:
         build_path: "./build"
@@ -217,7 +231,8 @@
       loop: "{{ network['channels'] }}"
 
     # Create CLI pod for peers with cli option enabled
-    - include_role:
+    - name: Create CLI pod for each peer with it enabled
+      include_role:
         name: "create/cli_pod"
       vars:
         peers: "{{ org.services.peers }}"

--- a/platforms/hyperledger-fabric/configuration/reset-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/reset-network.yaml
@@ -25,7 +25,8 @@
     - name: Uninstall flux
       shell: |
         KUBECONFIG={{ kubernetes.config_file }} kubectl delete secret git-auth-{{ network.env.type }}
-        KUBECONFIG={{ kubernetes.config_file }} helm delete --purge flux-{{ network.env.type }}
+        KUBECONFIG={{ kubernetes.config_file }} helm uninstall flux-{{ network.env.type }}
+        KUBECONFIG={{ kubernetes.config_file }} helm uninstall flux-{{ network.env.type }}-helm-operator
       vars:
         kubernetes: "{{ item.k8s }}"
       loop: "{{ network['organizations'] }}"

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/anchorpeer_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/anchorpeer_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ component_ns }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-orderer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-orderer.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}-ca
   namespace: {{ component_name }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}-ca
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-peer.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}-ca
   namespace: {{ component_name }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}-ca
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-tools.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-tools.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}-ca-tools
   namespace: {{ component_name }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}-ca-tools
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cli.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cli.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ component_ns }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: channel-{{ org.name | lower }}
   namespace: {{ component_ns }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: channel-{{ org.name | lower }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ name | lower | e }}-net
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/instantiate_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/instantiate_chaincode_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ namespace }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ namespace }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ component_ns }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ org_name }}-{{ orderer.name }}
   namespace: {{ namespace }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ org_name }}-{{ orderer.name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/upgrade_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/upgrade_chaincode_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ namespace }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ name }}-{{ peer_name }}
   namespace: {{ peer_ns }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ name }}-{{ peer_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/zkkafka.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/zkkafka.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: zkkafka-{{ org_name }}-orderer
   namespace: {{ namespace }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: zkkafka-{{ org_name }}-orderer
   chart:
@@ -17,7 +17,6 @@ spec:
       images:
         kafka: {{ kafka_image }}
         zookeeper: {{ zookeeper_image }}
-      
     storage: 
       storageclassname: {{ org_name }}sc
       storagesize: 512Mi

--- a/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/nested_sign_and_update.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/nested_sign_and_update.yaml
@@ -67,5 +67,5 @@
 # Delete the cli   
 - name: "delete cli {{ peer.name }}-{{ participant.name }}-cli"
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} helm del --purge {{ peer.name }}-{{ participant.name }}-cli
+    KUBECONFIG={{ org.k8s.config_file }} helm uninstall {{ peer.name }}-{{ participant.name }}-cli
   when: existing_cli.resources|length == 0

--- a/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/nested_update_channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/nested_update_channel.yaml
@@ -49,5 +49,5 @@
 # Delete the cli   
 - name: "delete cli {{ peer.name }}-{{ participant.name }}-cli"
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} helm del --purge {{ peer.name }}-{{ participant.name }}-cli
+    KUBECONFIG={{ org.k8s.config_file }} helm uninstall {{ peer.name }}-{{ participant.name }}-cli
   when: existing_cli.resources|length == 0


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Update Hyperledger Fabric network code to be compatible with Helm 3 (v 1.4)
- Update Supplychain reference app to be compatible with Helm 3
- Added role/task names to `deploy-network.yaml` to be able to restart at certain parts of playbook with the `--start-at-task=${TASK_NAME}` flag
- Changed Docker tags for Fabric ref-app to be consistent with our other tagging strategy
 
**To be reviewed by**
@jagpreetsinghsasan @lakshyakumar @suvajit-sarkar 

**Linked issue**
#1019
