### PR TITLE
[ Fabric ] Upgrade Fabric v2.2 to Helm 3

### DIFF
--- a/platforms/hyperledger-fabric/charts/approve_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for chaincode instantiation on a peer
 name: approve_chaincode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
         app: approvechaincode-{{ $.Values.chaincode.name }}-{{ $.Values.chaincode.version }}
+        app.kubernetes.io/name: approvechaincode-{{ $.Values.chaincode.name }}{{ $.Values.chaincode.version }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
@@ -133,15 +136,15 @@ spec:
           PACKAGE_ID=$(sed -n "/${CC_NAME}_${CC_VERSION}/{s/^Package ID: //; s/, Label:.*$//; p;}" log.txt)
           echo "Package Id Extracted"
 
-          echo "Endorsing policy :${ENDORSEMENT_POLICIES}"
+          echo "Endorsing policy:${ENDORSEMENT_POLICIES}"
           if [ -z ${ENDORSEMENT_POLICIES} ]
           then
             ## approve for myorg
-            echo "peer query approve"
+            echo "peer query approve without endorsement"
             peer lifecycle chaincode approveformyorg -o ${ORDERER_URL} --tls ${CORE_PEER_TLS_ENABLED} --cafile ${ORDERER_CA} --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --package-id ${PACKAGE_ID} --sequence ${CHAINCODE_VERSION} --init-required > log.txt
           else
             ## approve for myorg
-            echo "peer query approve"
+            echo "peer query approve with endorsement policies"
             peer lifecycle chaincode approveformyorg -o ${ORDERER_URL} --tls ${CORE_PEER_TLS_ENABLED} --cafile ${ORDERER_CA} --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --package-id ${PACKAGE_ID} --sequence ${CHAINCODE_VERSION} --init-required --signature-policy {{ $.Values.chaincode.endorsementpolicies | quote }} > log.txt  
           fi
           

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/Chart.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "2.0"
 description: A Helm chart for chaincode instantiation on a peer
 name: commit_chaincode
-version: 0.1.0
+version: 0.2.0

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
         app: commitchaincode-{{ $.Values.chaincode.name }}-{{ $.Values.chaincode.version }}
+        app.kubernetes.io/name: commitchaincode-{{ $.Values.chaincode.name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}

--- a/platforms/hyperledger-fabric/configuration/chaincode-install-instantiate.yaml
+++ b/platforms/hyperledger-fabric/configuration/chaincode-install-instantiate.yaml
@@ -13,14 +13,16 @@
   gather_facts: no
   tasks:
 
-    - include_role:
+    - name: Install chaincode
+      include_role:
         name: "create/chaincode/install"
       vars:
         docker_url: "{{ network.docker.url }}"
       loop: "{{ network['organizations'] }}"
       when: item.type == 'peer' and item.org_status == 'new'
 
-    - include_role:
+    - name: Instantiate chaincode
+      include_role:
         name: "create/chaincode/instantiate"
       vars:
         participants: "{{ item.participants }}"
@@ -28,7 +30,8 @@
       loop: "{{ network['channels'] }}"
       when: add_new_org == 'false' and '1.4' in network.version
 
-    - include_role:
+    - name: "Approve chaincode"
+      include_role:
         name: "create/chaincode/approve"
       vars:
         participants: "{{ item.participants }}"
@@ -36,7 +39,8 @@
       loop: "{{ network['channels'] }}"
       when: participants is defined and '2.' in network.version
 
-    - include_role:
+    - name: Commit chaincode
+      include_role:
         name: "create/chaincode/commit"
       vars:
         participants: "{{ item.participants }}"
@@ -47,7 +51,8 @@
         
     # This task invokes chaincode after the chaincode installation for the new organization to 
     # be added in existing network
-    - include_role:
+    - name: Invoke chaincode
+      include_role:
         name: "create/chaincode/invoke"
       vars:
         participants: "{{ item.participants }}"

--- a/platforms/hyperledger-fabric/configuration/create-join-channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/create-join-channel.yaml
@@ -56,6 +56,7 @@
         profile_name: "{{ item.channel_name }}"
         add_new_org: 'false'
       loop: "{{ network['channels'] }}"
+      when: item.channel_status == 'new'
 
     # This role creates the value file for creating channel from one organization
     # to the vault.
@@ -66,6 +67,7 @@
         participants: "{{ item.participants }}"
         docker_url: "{{ network.docker.url }}"
       loop: "{{ network['channels'] }}"
+      when: item.channel_status == 'new'
 
     # This role creates the value file for joining channel from each participating peer
     # to the vault.
@@ -76,6 +78,7 @@
         docker_url: "{{ network.docker.url }}"
         participants: "{{ item.participants }}"
       loop: "{{ network['channels'] }}"
+      when: item.channel_status == 'new'
       
     # delete build directory
     - name: Remove build directory

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/approve_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/approve_chaincode_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ namespace }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/commit_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/commit_chaincode_job.tpl
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: {{ component_name }}
   namespace: {{ namespace }}
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: {{ component_name }}
   chart:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
@@ -1,12 +1,12 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: channel-{{ org.name | lower }}
+  name: createchannel-{{component_name}}-{{ org.name | lower }}
   namespace: {{ component_ns }}
   annotations:
     fluxcd.io/automated: "false"
 spec:
-  releaseName: channel-{{ org.name | lower }}
+  releaseName: createchannel-{{ component_name }}-{{ org.name | lower }}
   chart:
     git: {{ git_url }}
     ref: {{ git_branch }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
@@ -1,12 +1,12 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: {{ component_name }}
+  name: joinchannel-{{ peer.name }}-{{ component_name }}
   namespace: {{ component_ns }}
   annotations:
     fluxcd.io/automated: "false"
 spec:
-  releaseName: {{ component_name }}
+  releaseName: joinchannel-{{ peer.name }}-{{ component_name }}
   chart:
     git: {{ git_url }}
     ref: {{ git_branch }}


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Update Fabric v2.2 code to compatible with Helm 3 
- Fix `createchannel`/`joinchannel` duplicate release name when adding new channel
- Fix `create-join-channel.yaml` annotations for incorporating `channel_status`
- Add task names to `chaincode-install-instantiate.yaml` to be able to use the `--start-with-task` flag on the `ansible-playbook` command

---

The following components have been (manually) tested:
- Main network deployment
- Add new organization
- Add new channel
- Install & instantiate chaincode on new organization
- Upgrade chaincode to next version

(A more detailed description of the components are found on the ticket description #1098)

**To be reviewed by**
@lakshyakumar @suvajit-sarkar @jagpreetsinghsasan 

**Linked issue**
Resolves #1098 
