### PR TITLE
[ Fabric ] Adding the support of upgarding chaincode for Fabric 2.2

### DIFF
--- a/docs/source/operations/upgrading_chaincode.md
+++ b/docs/source/operations/upgrading_chaincode.md
@@ -1,13 +1,15 @@
 <a name = "upgrading-chaincode"></a>
 # Upgrading chaincode in Hyperledger Fabric
 
-- [Pre-requisites](#pre_req)
-- [Modifying configuration file](#create_config_file)
-- [Running playbook to upgrade chaincode to new version in Hyperledger Fabric network](#run_network)
+- [Upgrading chaincode in Hyperledger Fabric](#upgrading-chaincode-in-hyperledger-fabric)
+  - [Pre-requisites](#pre-requisites)
+  - [Modifying configuration file](#modifying-configuration-file)
+  - [Run playbook for Fabric version 1.4.x](#run-playbook-for-fabric-version-14x)
+  - [Run playbook for Fabric version 2.2.x](#run-playbook-for-fabric-version-22x)
 
 <a name = "pre_req"></a>
 ## Pre-requisites
-Hyperledger Fabric network deployed, network.yaml configuration file already set and chaincode is installed and instantiated.
+Hyperledger Fabric network deployed, network.yaml configuration file already set and chaincode is installed and instantiated or packaged, approved and commited in case of Fabric version 2.2.
 
 <a name = "create_config_file"></a>
 ## Modifying configuration file
@@ -35,8 +37,9 @@ network:
           ..
           chaincode:
             name: "chaincode_name" #This has to be replaced with the name of the chaincode
-            version: "chaincode_version" # This has to be different than the current version
+            version: "chaincode_version" # This has to be greater than the current version, should be an integer.
             maindirectory: "chaincode_main"  #The main directory where chaincode is needed to be placed
+            lang: "java" # The chaincode language, optional field with default vaule of 'go'.
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_password"
@@ -48,13 +51,22 @@ network:
 ```
 
 <a name = "run_network"></a>
-## Run playbook
+## Run playbook for Fabric version 1.4.x
 
-The playbook [chaincode-upgrade.yaml](https://github.com/hyperledger-labs/blockchain-automation-framework/tree/master/platforms/hyperledger-fabric/configuration/chaincode-upgrade.yaml) is used to upgrade chaincode to a new version in the existing fabric network.
+The playbook [chaincode-upgrade.yaml](https://github.com/hyperledger-labs/blockchain-automation-framework/tree/master/platforms/hyperledger-fabric/configuration/chaincode-upgrade.yaml) is used to upgrade chaincode to a new version in the existing fabric network with version 1.4.x.
 This can be done by using the following command
 
 ```
     ansible-playbook platforms/hyperledger-fabric/configuration/chaincode-upgrade.yaml --extra-vars "@path-to-network.yaml"
+```
+
+## Run playbook for Fabric version 2.2.x
+
+The playbook [chaincode-install-instantiate.yaml](https://github.com/hyperledger-labs/blockchain-automation-framework/tree/master/platforms/hyperledger-fabric/configuration/chaincode-install-instantiate.yaml) is used to upgrade chaincode to a new version in the existing fabric network with version 2.2.x.
+This can be done by using the following command
+
+```
+    ansible-playbook platforms/hyperledger-fabric/configuration/chaincode-install-instantiate.yaml --extra-vars "@path-to-network.yaml" -e "add_new_org='false'"
 ```
 
 ---

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
@@ -133,8 +133,8 @@ spec:
           
           echo "Extracting package id"
           peer lifecycle chaincode queryinstalled > log.txt
-          PACKAGE_ID=$(sed -n "/${CC_NAME}_${CC_VERSION}/{s/^Package ID: //; s/, Label:.*$//; p;}" log.txt)
-          echo "Package Id Extracted"
+          PACKAGE_ID=$(cat log.txt | grep "${CHAINCODE_NAME}_${CHAINCODE_VERSION}" | sed -n "/${CC_NAME}_${CC_VERSION}/{s/^Package ID: //; s/, Label:.*$//; p;}")
+          echo "Package Id Extracted ${PACKAGE_ID}"
 
           echo "Endorsing policy:${ENDORSEMENT_POLICIES}"
           if [ -z ${ENDORSEMENT_POLICIES} ]

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
@@ -166,7 +166,7 @@ spec:
           echo $COMMIT_ARGUMENTS>COMMIT_ARGUMENTS.txt
           COMMIT_ARGUMENTS=$(< COMMIT_ARGUMENTS.txt)
           
-          COMMIT_CMD="peer lifecycle chaincode commit -o ${ORDERER_URL} --tls ${CORE_PEER_TLS_ENABLED} --cafile $ORDERER_CA --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --sequence 1 --init-required"
+          COMMIT_CMD="peer lifecycle chaincode commit -o ${ORDERER_URL} --tls ${CORE_PEER_TLS_ENABLED} --cafile $ORDERER_CA --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --sequence ${CHAINCODE_VERSION} --init-required"
           
           for item in $ENDORSERS_CORE_PEER_ADDR
           do
@@ -187,14 +187,14 @@ spec:
           then
             ## check commit readiness
             echo "peer query commitreadiness"
-            peer lifecycle chaincode checkcommitreadiness --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --sequence 1 --init-required --output json
+            peer lifecycle chaincode checkcommitreadiness --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --sequence ${CHAINCODE_VERSION} --init-required --output json
             ## commit chaincode
             echo "peer query commit : Endorsement Policy null "
             eval ${COMMIT_CMD}
           else
             ## check commit readiness
             echo "peer query commit readiness"
-            peer lifecycle chaincode checkcommitreadiness --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --sequence 1 --init-required --output json --signature-policy {{ $.Values.chaincode.endorsementpolicies | quote }} > log.txt
+            peer lifecycle chaincode checkcommitreadiness --channelID ${CHANNEL_NAME} --name ${CHAINCODE_NAME} --version ${CHAINCODE_VERSION} --sequence ${CHAINCODE_VERSION} --init-required --output json --signature-policy {{ $.Values.chaincode.endorsementpolicies | quote }} > log.txt
             cat log.txt
             ## commit chaincode
             echo "peer query commit"

--- a/platforms/hyperledger-fabric/configuration/add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-organization.yaml
@@ -1,11 +1,12 @@
-# This playbook adds an organization to a DLT network on existing Kubernetes clusters
+# This playbook adds an organization to a DLT with Fabric network on existing Kubernetes clusters
 # The Kubernetes clusters should already be created and the infomation to connect to the
 #  clusters be updated in the network.yaml file that is used as an input to this playbook
 ###########################################################################################
 # To Run this playbook from this directory, use the following command (network.yaml also in this directory)
-#  ansible-playbook add-organization.yaml -e "@./network.yaml"
+#  ansible-playbook add-organization.yaml -e "@./network.yaml" -e "add_new_org='true'"
 ############################################################################################
 # Please ensure that the ../../shared/configuration playbooks have been run and a DLT network exists.
+# Please ensure the orderer certificates are placed on the paths mentioned in orderer.certificate in network.yaml
 ---
   # This will apply to ansible_provisioners. /etc/ansible/hosts should be configured with this group
 - hosts: ansible_provisioners

--- a/platforms/hyperledger-fabric/configuration/add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-peer.yaml
@@ -1,11 +1,12 @@
-# This playbook adds an organization to a DLT network on existing Kubernetes clusters
+# This playbook adds a new peer to an exisitng organization in an existing Fabric DLT network on existing Kubernetes clusters
 # The Kubernetes clusters should already be created and the infomation to connect to the
 #  clusters be updated in the network.yaml file that is used as an input to this playbook
 ###########################################################################################
 # To Run this playbook from this directory, use the following command (network.yaml also in this directory)
-#  ansible-playbook add-organization.yaml -e "@./network.yaml"
+#  ansible-playbook add-peer.yaml -e "@./network.yaml" -e "add_new_org='false'" -e "add_peer='true'"
 ############################################################################################
 # Please ensure that the ../../shared/configuration playbooks have been run and a DLT network exists.
+# Please ensure the orderer certificates are placed on the paths mentioned in orderer.certificate in network.yaml
 ---
   # This will apply to ansible_provisioners. /etc/ansible/hosts should be configured with this group
 - hosts: ansible_provisioners

--- a/platforms/hyperledger-fabric/configuration/chaincode-install-instantiate.yaml
+++ b/platforms/hyperledger-fabric/configuration/chaincode-install-instantiate.yaml
@@ -1,13 +1,16 @@
 # This playbook is a subsequent playbook
 # This playbook does following
 # 1. Installs chaincode provided in network.yaml from each peer
-# 2. Instantiates chaincode from the creator participant peer of the channel( For Fabric 1.4)
-# 3. Approves chaincode for Org and Commits chaincode on the peer (Fabric 2.X)
+# 2. Instantiates chaincode from the creator participant peer of the channel( For Fabric 1.4.x)
+# 3. Approves chaincode for Org and Commits chaincode on the peer (Fabric 2.2.X)
+# 4. Upgrade chaincode by repeating the cahincode installation process on peers ( Fabric 2.2.x )
 ##########################################################################################
 # DO NOT RUN THIS IF YOU HAVE NOT RUN deploy-network.yaml and deployed the Fabric network
 ##########################################################################################
 # This playbook can only be run after all pods and orderers are available, and channel is created
 # Please use the same network.yaml to run this playbook as used for deploy-network.yaml
+# For upgrading the chaincode in fabric 2.2.x, chaincode.version field in network.yaml is also used as the sequence number
+# Use strictly increasing integer values for chaincode.version in network.yaml
 ---
 - hosts: ansible_provisioners
   gather_facts: no

--- a/platforms/hyperledger-fabric/configuration/chaincode-upgrade.yaml
+++ b/platforms/hyperledger-fabric/configuration/chaincode-upgrade.yaml
@@ -1,6 +1,6 @@
 # This playbook is a subsequent playbook
 # This playbook does following
-# 1. Upgrades the chaincode provided in network.yaml from each peer
+# 1. Upgrades the chaincode provided in network.yaml from each peer (for fabric version 1.4.x )
 ##########################################################################################
 # DO NOT RUN THIS IF YOU HAVE NOT RUN deploy-network.yaml and deployed the Fabric network
 ##########################################################################################


### PR DESCRIPTION
Signed-off-by: lakshyakumar <lakshya.kumar@accenture.com>

**Changelog**
- Add the support of upgarding chaincode for Fabric 2.2 using `chaincode-install-instantiate.yaml` playbook
- Fix the comments in the playbooks.
- Update operational guide for upgarding the chaincode in Fabric.

 

**Reviewed by**
@jagpreetsinghsasan 

 

**Linked issue**
#1133 
