### PR TITLE
[ Corda-Ent ] Update docker images & Helm templates

### DIFF
--- a/platforms/r3-corda-ent/charts/notary-initial-registration/templates/job.yaml
+++ b/platforms/r3-corda-ent/charts/notary-initial-registration/templates/job.yaml
@@ -230,7 +230,7 @@ spec:
             /bin/sh
             NETWORK_ROOT_TRUSTSTORE={{ $.Values.nodeConf.volume.baseDir }}/DATA/trust-stores/network-root-truststore.jks
             NETWORK_ROOT_TRUSTSTORE_PASSWORD=$(cat {{ $.Values.nodeConf.volume.baseDir }}/DATA/truststore/rootcats)
-
+            
             while true
             do
                 if [ ! -f certificates/nodekeystore.jks ] || [ ! -f certificates/sslkeystore.jks ] || [ ! -f certificates/truststore.jks ]

--- a/platforms/r3-corda-ent/charts/notary/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/notary/templates/deployment.yaml
@@ -308,7 +308,7 @@ spec:
           # add idman and networkmap certificates to java keystore
           yes | keytool -importcert -file ${BASE_DIR}/certificates/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts
           yes | keytool -importcert -file ${BASE_DIR}/certificates/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts          
-          
+
           #!/bin/sh
           KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/kspass)
           if [ -f {{ .Values.nodeConf.jarPath }}/corda.jar ]

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/db.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/db.tpl
@@ -8,8 +8,8 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ git_url }}
-    ref: {{ git_branch }}
+    git: {{ org.gitops.git_ssh }}
+    ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/h2
   values:
     nodeName: {{ node_name }}
@@ -18,17 +18,17 @@ spec:
     replicaCount: 1
     image:
       containerName: {{ container_name }}
-      imagePullSecret: {{ image_pull_secret }}
+      imagePullSecret: regcred
     resources:
       limits: 512Mi
       requests: 512Mi
     storage:
-      name: {{ storageclass }}
+      name: "cordaentsc"
       memory: 512Mi
     service:
       type: NodePort
       tcp:
-        port: {{ tcp_port }}
+        port: {{ tcp_port}}
         targetPort: {{ tcp_targetport }}
       web:
         targetPort: {{ web_targetport }}

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
@@ -8,18 +8,18 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ git_url }}
-    ref: {{ git_branch }}
+    git: {{ org.gitops.git_ssh }}
+    ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/node-initial-registration
   values:
-    nodeName: {{ node_name }}-registration
+    nodeName: {{ peer.name | lower }}-registration
     metadata:
       namespace: {{ component_ns }}
-      labels:
+      labels: {}
     image:
       initContainerName: {{ network.docker.url }}/{{ init_image }}
       nodeContainerName: {{ network.docker.url }}/{{ docker_image }}
-      imagepullsecret: {{ image_pull_secret }}
+      imagepullsecret: regcred
       pullPolicy: Always
     truststorePassword: password
     keystorePassword: password

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
@@ -8,8 +8,8 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ git_url }}
-    ref: {{ git_branch }}
+    git: {{ org.gitops.git_ssh }}
+    ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/notary
   values:
     nodeName: {{ component_name }}
@@ -83,7 +83,7 @@ spec:
         p2pPort: {{ notary_service.p2p.ambassador | default('10002') }}
         external_url_suffix: {{ org.external_url_suffix }}
         p2pAddress: {{ component_name }}.{{ org.external_url_suffix }}:{{ notary_service.p2p.ambassador | default('10002') }}
-      jarPath: bin
+      jarPath: /opt/cenm/bin
       configPath: etc
       cordaJar:
         memorySize: 1524

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
@@ -8,8 +8,8 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ git_url }}
-    ref: {{ git_branch }}
+    git: {{ org.gitops.git_ssh }}
+    ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/notary-initial-registration
   values:
     nodeName: {{ notary_service.name }}-initial-registration
@@ -71,7 +71,7 @@ spec:
         p2pPort: {{ notary_service.p2p.ambassador | default('10002') }}
         external_url_suffix: {{ org.external_url_suffix }}
         p2pAddress: {{ component_name }}.{{ org.external_url_suffix }}:{{ notary_service.p2p.ambassador | default('10002') }}
-      jarPath: bin
+      jarPath: /opt/cenm/bin
       configPath: etc
       cordaJar:
         memorySize: 1524

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
@@ -16,7 +16,7 @@ docker_images:
     pki-1.2: corda/enterprise-pki:1.2-zulu-openjdk8u242
     networkmap-1.2: corda/enterprise-networkmap:1.2-zulu-openjdk8u242
     idman-1.2: corda/enterprise-identitymanager:1.2-zulu-openjdk8u242
-    notary-1.2: corda/enterprise-notary:1.2-zulu-openjdk8u242
-    firewall: corda_image_firewall_4.4:latest
-    node: corda_image_ent_4.4:latest
+    notary-4.4: corda/enterprise-notary:4.4-zulu-openjdk8u242
+    firewall-4.4: corda/enterprise-firewall:4.4
+    node-4.4: corda/enterprise-node:4.4
   init_container: alpine-utils:1.0

--- a/platforms/r3-corda-ent/configuration/roles/setup/bridge/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/bridge/tasks/main.yaml
@@ -20,7 +20,7 @@
     component_name: "{{ peer.firewall.bridge.name }}"
     type: bridge
     name: "{{ org.name | lower }}"
-    corda_service_version: "firewall"
+    corda_service_version: "firewall-{{ org.version }}"
     charts_dir: "{{ org.gitops.chart_source }}"
     values_dir: "{{playbook_dir}}/../../../{{ org.gitops.release_dir }}"
 

--- a/platforms/r3-corda-ent/configuration/roles/setup/float/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/float/tasks/main.yaml
@@ -10,7 +10,7 @@
     component_name: "{{ peer.firewall.float.name }}"
     type: float
     name: "{{ org.name | lower }}"
-    corda_service_version: "firewall"
+    corda_service_version: "firewall-{{ org.version }}"
     charts_dir: "{{ org.gitops.chart_source }}"
     values_dir: "{{playbook_dir}}/../../../{{ org.gitops.release_dir }}"
 

--- a/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
@@ -100,7 +100,7 @@
     node_name: "{{ peer.name | lower }}"
     values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
     name: "{{ org.name | lower }}"
-    corda_service_version: node
+    corda_service_version: node-{{ org.version }}
     type: node
     doorman_url: "{{ network | json_query('network_services[?type==`idman`].uri') | first }}"
     networkmap_url: "{{ network | json_query('network_services[?type==`networkmap`].uri') | first }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/node_registration/tasks/nested_main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node_registration/tasks/nested_main.yaml
@@ -17,38 +17,32 @@
   vars:
     component_name: "{{ peer.name | lower }}db"
     type: "db"
-    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
     name: "{{ org.name | lower }}"
-    charts_dir: "{{ org.gitops.chart_source }}"
-    git_url: "{{ org.gitops.git_ssh }}"
-    git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ peer.name | lower }}"
-    image_pull_secret: "regcred"
-    storageclass: "cordaentsc"
+    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
+    charts_dir: "{{ org.gitops.chart_source }}"
     container_name: "index.docker.io/hyperledgerlabs/h2:2018"
+    helm_lint: "true"
+    # These variables are needed as the db.tpl is used for both notary & node registration
+    # The values for the below variables are fetched from different parts in the network.yaml
     tcp_port: "{{ peer.dbtcp.port }}"
     tcp_targetport: "{{ peer.dbtcp.targetPort }}"
     web_port: "{{ peer.dbweb.port }}"
     web_targetport: "{{ peer.dbweb.targetPort }}"
-    helm_lint: "true"
 
 - name: "Create value file for node registration"
   include_role:
     name: helm_component
   vars:
-    helm_lint: "true"
-    git_url: "{{ org.gitops.git_ssh }}"
-    git_branch: "{{ org.gitops.branch }}"
-    charts_dir: "{{ org.gitops.chart_source }}"
     component_name: "{{ peer.name | lower }}registration"
-    node_name: "{{ peer.name | lower }}"
-    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
-    name: "{{ org.name | lower }}"
-    corda_service_version: node
-    image_pull_secret: regcred
     type: node_registration
+    name: "{{ org.name | lower }}"
+    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
+    charts_dir: "{{ org.gitops.chart_source }}"
+    corda_service_version: node-{{ org.version }}
     doorman_url: "{{ network | json_query('network_services[?type==`idman`].uri') | first }}"
     networkmap_url: "{{ network | json_query('network_services[?type==`networkmap`].uri') | first }}"
+    helm_lint: "true"
   when: node_certs.failed
 
 # Git Push : Pushes the above generated files to git directory 

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
@@ -20,20 +20,18 @@
   vars:
     component_name: "{{ org.services.notary.name | lower }}db"
     type: "db"
-    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
     name: "{{ org.name | lower }}"
-    charts_dir: "{{ org.gitops.chart_source }}"
-    git_url: "{{ org.gitops.git_ssh }}"
-    git_branch: "{{ org.gitops.branch }}"
     node_name: "{{ org.services.notary.name | lower }}"
-    image_pull_secret: "regcred"
-    storageclass: "cordaentsc"
+    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
+    charts_dir: "{{ org.gitops.chart_source }}"
     container_name: "index.docker.io/hyperledgerlabs/h2:2018"
+    helm_lint: "true"
+    # These variables are needed as the db.tpl is used for both notary & node registration
+    # The values for the below variables are fetched from different parts in the network.yaml
     tcp_port: "{{ org.services.notary.dbtcp.port }}"
     tcp_targetport: "{{ org.services.notary.dbtcp.targetPort }}"
     web_port: "{{ org.services.notary.dbweb.port }}"
     web_targetport: "{{ org.services.notary.dbweb.targetPort }}"
-    helm_lint: "true"
 
 # ----------------------------------------------------------------------  
 # Check if notary already registered or not
@@ -65,7 +63,7 @@
     idman_domain: "{{ idman_url.split(':')[1] | regex_replace('/', '') }}"    
     networkmap_url: "{{ network | json_query('network_services[?type==`networkmap`].uri') | first }}"
     networkmap_domain: "{{ networkmap_url.split(':')[1] | regex_replace('/', '') }}"
-    corda_service_version: notary-{{ org.version }}
+    corda_service_version: notary-{{ network.version }}
   when: nodekeystore_result.failed == True
 
 - name: "Push the created deployment files to repository"

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/main.yaml
@@ -32,17 +32,13 @@
     notary_service: "{{ org.services.notary }}"
     component_name: "{{ notary_service.name | lower }}"
     name: "{{ org.name | lower }}"
-    values_dir: "{{playbook_dir}}/../../../{{ org.gitops.release_dir }}"
+    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
     charts_dir: "{{ org.gitops.chart_source }}"
-    git_url: "{{ org.gitops.git_ssh }}"
-    git_branch: "{{ org.gitops.branch }}"
     idman_url: "{{ network | json_query('network_services[?type==`idman`].uri') | first }}"
     idman_domain: "{{ idman_url.split(':')[1] | regex_replace('/', '') }}"    
     networkmap_url: "{{ network | json_query('network_services[?type==`networkmap`].uri') | first }}"
     networkmap_domain: "{{ networkmap_url.split(':')[1] | regex_replace('/', '') }}"
-    corda_service_version: notary-{{ org.version }}
-    p2p_port: "{{ org.services.notary.p2p.port }}"
-    ambassador_p2pPort: "{{ org.services.notary.p2p.ambassador }}"
+    corda_service_version: notary-{{ network.version }}
 
 # Push the notary deployment files to repository
 - name: Push the created deployment files to repository

--- a/platforms/r3-corda-ent/images/notary.dockerfile
+++ b/platforms/r3-corda-ent/images/notary.dockerfile
@@ -1,3 +1,3 @@
-FROM corda/notary:1.2-zulu-openjdk8u242
+FROM corda/enterprise-notary:4.4-zulu-openjdk8u242
 USER root
 WORKDIR /opt/corda


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Update Helm templates to directly reference the `network.yaml`
   - `node.tpl`
   - `node_initial_registration.tpl`
   - `notary.tpl`
   - `notary_initial_registration.tpl`
- Update Notary Docker image to Enterprise version 4.4
- Update Notary & Notary initial registration charts to change `jarPath` - moved to `opt/cenm/bin`
- Update `roles/setup/notary/main.yaml` to add `network.version`
- Update `roles/setup/notary_initial_registration/main.yaml` to add `network.version`
- Added `org.version` to organization where `type == node` - used to determine the Docker images for Node + Firewall
- Updated private Docker repository with new tags of images (old ones will be deleted upon merge & pipeline completion)
 
**NOTE** A PR will be made to `baf-configuration` to update the `network.yaml`s for Corda Enterprise

**To be reviewed by**
@jagpreetsinghsasan @suvajit-sarkar 

**Linked issue**
Resolves #1123 
Resolves #1129 
