### PR TITLE
[feat] Configurable secret path for hasicorp vault

### DIFF
--- a/docs/source/architectureref/certificates_path_list_besu.md
+++ b/docs/source/architectureref/certificates_path_list_besu.md
@@ -1,6 +1,8 @@
 Certificate Paths on Vault for Hyperledger Besu Network
 -------------------------------------------------------
 
+* Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
+
 ### For IBFT2 WIP
 
 | Path                                                                              | Key Name               | Description         |

--- a/docs/source/architectureref/certificates_path_list_corda.md
+++ b/docs/source/architectureref/certificates_path_list_corda.md
@@ -1,6 +1,8 @@
 Certificate Paths on Vault for Corda Network
 ---------------------------------------------
 
+* Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
+
 ### For Networkmap 
 
 | Path (networkmap crypto material) | Crypto-material         | Type        |

--- a/docs/source/architectureref/certificates_path_list_corda_ent.md
+++ b/docs/source/architectureref/certificates_path_list_corda_ent.md
@@ -1,6 +1,7 @@
 Certificate Paths on Vault for Corda Enterprise
 -----------------------------------------------
-All values must be Base64 encoded files as BAF decodes them.
+* All values must be Base64 encoded files as BAF decodes them.
+* Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
 
 ### For CENM
 

--- a/docs/source/architectureref/certificates_path_list_fabric.md
+++ b/docs/source/architectureref/certificates_path_list_fabric.md
@@ -1,6 +1,8 @@
 Certificate Paths on Vault for Fabric Network
 ---------------------------------------------
 
+* Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
+
 ## For each channel
 | Path                                                                       | Key (for Vault)                  | Type        |
 |-----------------------------------------------------------------------------------------------------------|-------------------------------------|-------------|

--- a/docs/source/architectureref/certificates_path_list_quorum.md
+++ b/docs/source/architectureref/certificates_path_list_quorum.md
@@ -1,6 +1,8 @@
 Certificate Paths on Vault for Quorum Network
 ---------------------------------------------
 
+* Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
+
 ### For IBFT/ RAFT
 
 | Path                                                                              | Key Name               | Description         |

--- a/docs/source/architectureref/corda-ent.md
+++ b/docs/source/architectureref/corda-ent.md
@@ -55,6 +55,7 @@ Detailed information on helm charts can be referred [here](../developer/corda-en
 <a name="vault-config"></a>
 ## Vault Configuration WIP
 The Blockchain Automation Framework stores their `crypto` and `credentials` immediately within the secret secrets engine.
+Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
 
 | Crypto Material Path | Credentials Path     |
 |----------------------|----------------------|

--- a/docs/source/architectureref/corda.md
+++ b/docs/source/architectureref/corda.md
@@ -47,7 +47,7 @@ Detailed information on helm charts can be referred [here](../developer/corda-he
 <a name="vault-config"></a>
 ## Vault Configuration
 The Blockchain Automation Framework stores their `crypto` and `credentials` immediately within the secret secrets engine.
-
+Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
 | Crypto Material Path | Credentials Path     |
 |----------------------|----------------------|
 | `secret/<servicename>`      | `secret/<servicename>/credentials` |

--- a/docs/source/architectureref/hyperledger-besu.md
+++ b/docs/source/architectureref/hyperledger-besu.md
@@ -64,6 +64,7 @@ Detailed information on helm charts can be referred [here](../developer/besu-hel
 
 The Blockchain Automation Framework stores their `crypto` immediately in the Hashicorp Vault secrets engine.
 The crypto is stored by each organization under path `secret/org_namespace` - it contains node keys, keystore, passwords, TM keys, and CA certificates for proxy connections.
+Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
 
 
 The complete key paths in the Vault can be referred [here](certificates_path_list_besu.md).

--- a/docs/source/architectureref/hyperledger-fabric.md
+++ b/docs/source/architectureref/hyperledger-fabric.md
@@ -78,7 +78,7 @@ Detailed information on helm charts can be referred [here](../developer/fabric-h
 ## Vault Configuration
 
 The Blockchain Automation Framework stores their `crypto` and `credentials` immediately within the secret secrets engine.
-
+Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
 | Crypto Material Path | Credentials Path |
 |----------------------|----------------------|
 | `secret/crypto` | `secret/credentials` |

--- a/docs/source/architectureref/quorum.md
+++ b/docs/source/architectureref/quorum.md
@@ -68,6 +68,6 @@ Detailed information on helm charts can be referred [here](../developer/quorum-h
 
 The Blockchain Automation Framework stores their `crypto` immediately in the Hashicorp Vault secrets engine.
 The crypto is stored by each organization under path `secret/org_namespace` - it contains node keys, keystore, passwords, TM keys, and CA certificates for proxy connections.
-
+Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secret/`.
 
 The complete key paths in the Vault can be referred [here](certificates_path_list_quorum.md).

--- a/docs/source/developer/dev_prereq.md
+++ b/docs/source/developer/dev_prereq.md
@@ -160,7 +160,7 @@ We need [Hashicorp Vault](https://www.vaultproject.io/) for the certificate and 
    ```bash
    export VAULT_ADDR='http://<Your Vault local IP address>:8200' #e.g. http://192.168.0.1:8200
    export VAULT_TOKEN="<Your Vault root token>"
-   vault secrets enable -version=1 -path=secret kv
+   vault secrets enable -version=1 -path=<Your Secret Engine> kv
    ```
 
 ### Setting up Minikube

--- a/docs/source/operations/configure_prerequisites.md
+++ b/docs/source/operations/configure_prerequisites.md
@@ -81,7 +81,7 @@ vault operator unseal << unseal-key-from-above >>
 ```
 vault login << give the root token >>
 ```
-* Enable secrets engine
+* Enable secrets engine. Blockchain Automation Framework uses the secret path `secret` by default. This can be changed in the network.yaml, in which case it will need to be enabled with the selected path.
 ```
 vault secrets enable -version=1 -path=secret kv
 ```

--- a/examples/supplychain-app/configuration/roles/helm_component/templates/expressapi-quorum.tpl
+++ b/examples/supplychain-app/configuration/roles/helm_component/templates/expressapi-quorum.tpl
@@ -18,7 +18,7 @@ spec:
     replicaCount: 1
     vault:
       address: {{ organization_data.vault.url }}
-      secretprefix: secret/{{ component_ns }}/smartContracts
+      secretprefix: {{ organization_data.vault.secret_path | default('secret') }}/{{ component_ns }}/smartContracts
       serviceaccountname: vault-auth
       keyname: General
       role: vault-role

--- a/examples/supplychain-app/configuration/roles/helm_component/templates/restserver.tpl
+++ b/examples/supplychain-app/configuration/roles/helm_component/templates/restserver.tpl
@@ -29,7 +29,7 @@ spec:
       address: {{ component_vault.url }}
       role: vault-role
       authpath: {{ component_ns }}-auth
-      secretprefix: secret/crypto/peerOrganizations/{{ component_ns }}
+      secretprefix: {{ component_vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}
       serviceaccountname: vault-auth
       imagesecretname: regcred
       image: hyperledgerlabs/alpine-utils:1.0

--- a/examples/supplychain-app/configuration/roles/helm_component/templates/webserver-cordaent.tpl
+++ b/examples/supplychain-app/configuration/roles/helm_component/templates/webserver-cordaent.tpl
@@ -69,9 +69,9 @@ spec:
       role: vault-role
       authpath: cordaent{{ node.name|e }}
       serviceaccountname: vault-auth
-      rpcusersecretprefix: secret/{{ organization_data.name}}/{{ node.name }}/credentials
-      keystoresecretprefix: secret/{{ organization_data.name}}/{{ node.name }}/credentials
-      certsecretprefix: secret/{{ organization_data.name}}/{{ node.name }}/certs
+      rpcusersecretprefix: {{ component_vault.secret_path | default('secret') }}/{{ organization_data.name}}/{{ node.name }}/credentials
+      keystoresecretprefix: {{ component_vault.secret_path | default('secret') }}/{{ organization_data.name}}/{{ node.name }}/credentials
+      certsecretprefix: {{ component_vault.secret_path | default('secret') }}/{{ organization_data.name}}/{{ node.name }}/certs
     node:
       readinesscheckinterval: 10
       readinessthreshold: 15

--- a/examples/supplychain-app/configuration/roles/setup/smartContractAddress/tasks/main.yaml
+++ b/examples/supplychain-app/configuration/roles/setup/smartContractAddress/tasks/main.yaml
@@ -2,7 +2,7 @@
 # Add the smart contract address to the vault
 - name: "Putting contract address {{contract_address}} to vault of {{ organization_data.name | lower }}"
   shell: |
-    vault kv put secret/{{component_ns}}/smartContracts/{{contract_name}} address="$(echo ${ADDRESS} )" 
+    vault kv put {{ component_vault.secret_path | default('secret') }}/{{component_ns}}/smartContracts/{{contract_name}} address="$(echo ${ADDRESS} )" 
   environment:
     VAULT_ADDR: "{{ component_vault.url }}"
     VAULT_TOKEN: "{{ component_vault.root_token }}"

--- a/examples/supplychain-app/configuration/samples/network-cordav2.yaml
+++ b/examples/supplychain-app/configuration/samples/network-cordav2.yaml
@@ -67,6 +67,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -145,6 +146,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -219,6 +221,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -292,6 +295,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -365,6 +369,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password

--- a/examples/supplychain-app/configuration/samples/network-fabricv2.yaml
+++ b/examples/supplychain-app/configuration/samples/network-fabricv2.yaml
@@ -116,6 +116,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -190,6 +191,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -282,6 +284,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -372,6 +375,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password
@@ -462,6 +466,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
 
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_password

--- a/examples/supplychain-app/configuration/samples/network-quorum-supplychain.yaml
+++ b/examples/supplychain-app/configuration/samples/network-quorum-supplychain.yaml
@@ -78,6 +78,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -147,6 +148,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -221,6 +223,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -286,6 +289,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
@@ -21,7 +21,7 @@
 # Checks if certificates for root are already created and stored in vault.
 - name: Check if root certs already created
   shell: |
-    vault kv get -format=yaml secret/besu-{{ network.env.type }}/rootca
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/besu-{{ network.env.type }}/rootca
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -31,7 +31,7 @@
 # Checks if certificates  are already created and stored in vault.
 - name: Check if ambassador and tls certs already created
   shell: |
-    vault kv get -format=yaml secret/{{ component_ns }}/crypto/{{ node_name }}/tls
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ node_name }}/tls
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -65,7 +65,7 @@
 # Stores the genrated rootca.pem and rootca.key
 - name: Putting root certs to vault
   shell: |
-    vault kv put secret/besu-{{ network.env.type }}/rootca rootca_pem="$(cat {{rootca}}/rootca.pem | base64)" rootca_key="$(cat {{ rootca }}/rootca.key | base64)"
+    vault kv put {{ vault.secret_path | default('secret') }}/besu-{{ network.env.type }}/rootca rootca_pem="$(cat {{rootca}}/rootca.pem | base64)" rootca_key="$(cat {{ rootca }}/rootca.key | base64)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -143,7 +143,7 @@
 # Stores the genreated ambassador tls certificates to vault if tls is off for network
 - name: Putting ambassador certs to vault
   shell: |
-    vault kv put secret/{{component_ns}}/crypto/{{node_name}}/tls rootca_pem="$(cat {{rootca}}/rootca.pem | base64)" rootca_key="$(cat {{ rootca }}/rootca.key | base64)" ambassadorcrt="$(cat {{ambassadortls}}/{{node_name}}-certchain.pem | base64)" ambassadorkey="$(cat {{ambassadortls}}/{{node_name}}.key | base64)" 
+    vault kv put {{ vault.secret_path | default('secret') }}/{{component_ns}}/crypto/{{node_name}}/tls rootca_pem="$(cat {{rootca}}/rootca.pem | base64)" rootca_key="$(cat {{ rootca }}/rootca.key | base64)" ambassadorcrt="$(cat {{ambassadortls}}/{{node_name}}-certchain.pem | base64)" ambassadorkey="$(cat {{ambassadortls}}/{{node_name}}.key | base64)" 
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -154,7 +154,7 @@
 # This task stores the genreated ambassador tls certificates to vault
 - name: Putting tls certs to vault
   shell: |
-    vault kv put secret/{{component_ns}}/crypto/{{node_name}}/tls rootca_pem="$(cat {{rootca}}/rootca.pem | base64)" rootca_key="$(cat {{ rootca }}/rootca.key | base64)" ambassadorcrt="$(cat {{ambassadortls}}/{{node_name}}-certchain.pem | base64)" ambassadorkey="$(cat {{ambassadortls}}/{{node_name}}.key | base64)" keystore="$(cat {{ambassadortls}}/{{ node_name }}-besu-node.pkcs12 | base64)" password="$(cat {{ambassadortls}}/{{ node_name }}-password | base64)" knownServer="$(cat {{ambassadortls}}/{{ node_name }}-knownServer | base64)"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{component_ns}}/crypto/{{node_name}}/tls rootca_pem="$(cat {{rootca}}/rootca.pem | base64)" rootca_key="$(cat {{ rootca }}/rootca.key | base64)" ambassadorcrt="$(cat {{ambassadortls}}/{{node_name}}-certchain.pem | base64)" ambassadorkey="$(cat {{ambassadortls}}/{{node_name}}.key | base64)" keystore="$(cat {{ambassadortls}}/{{ node_name }}-besu-node.pkcs12 | base64)" password="$(cat {{ambassadortls}}/{{ node_name }}-password | base64)" knownServer="$(cat {{ambassadortls}}/{{ node_name }}-knownServer | base64)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/tasks/add_to_vault.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/tasks/add_to_vault.yaml
@@ -1,7 +1,7 @@
 # This tasks copy the crypto material to the vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault kv put secret/{{ component_ns }}/crypto/{{ peer.name }}/data key="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/data/key)" key.pub="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/data/key.pub)" nodeAddress="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/data/nodeAddress)"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/data key="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/data/key)" key.pub="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/data/key.pub)" nodeAddress="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/data/nodeAddress)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -11,7 +11,7 @@
 
 - name: Copy genesis to Vault
   shell: |
-    vault kv put secret/{{ component_ns }}/crypto/genesis genesis="{{ genesis }}" 
+    vault kv put {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/genesis genesis="{{ genesis }}" 
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/tasks/check_vault.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/ibft/tasks/check_vault.yaml
@@ -1,7 +1,7 @@
 # This tasks checks for the crypto material to the vault
 - name: Check the crypto material to Vault
   shell: |
-    vault read -field=key secret/{{ component_ns }}/crypto/{{ item.name }}/data
+    vault read -field=key {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ item.name }}/data
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/orion/tasks/check_vault.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/orion/tasks/check_vault.yaml
@@ -2,7 +2,7 @@
 # This tasks checks for the crypto material to the vault
 - name: Check the crypto material to Vault
   shell: |
-    vault read -field=key secret/{{ component_ns }}/crypto/{{ item.name }}/orion
+    vault read -field=key {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ item.name }}/orion
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/crypto/orion/tasks/generate_nodekey.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/crypto/orion/tasks/generate_nodekey.yaml
@@ -19,7 +19,7 @@
 # This tasks copy the crypto material to the vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault kv put secret/{{ component_ns }}/crypto/{{ peer.name }}/orion key="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/nodeKey.key)" key.pub="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/nodeKey.pub)" password="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/password)"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/orion key="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/nodeKey.key)" key.pub="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/nodeKey.pub)" password="$(cat {{ build_path }}/crypto/{{ component_ns }}/{{ peer.name }}/password)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/ibft/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/ibft/tasks/main.yaml
@@ -42,7 +42,7 @@
 # This task gets the genesis file when there isno local genesis
 - name: get genesis from vault
   shell: |
-    vault kv get -field=genesis secret/{{ component_ns }}/crypto/genesis
+    vault kv get -field=genesis {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/genesis
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/ibft/tasks/nested_enode_data.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/ibft/tasks/nested_enode_data.yaml
@@ -17,7 +17,7 @@
 # Fetch nodekey from vault
 - name: Get the nodekey from vault and generate the enode
   shell: |
-    vault read -field=key.pub secret/{{ org.name }}-bes/crypto/{{ peer.name }}/data | sed -r 's/^.{2}//' > {{ build_path }}/{{ org.name }}/{{ peer.name }}/enode
+    vault read -field=key.pub {{ vault.secret_path | default('secret') }}/{{ org.name }}-bes/crypto/{{ peer.name }}/data | sed -r 's/^.{2}//' > {{ build_path }}/{{ org.name }}/{{ peer.name }}/enode
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/validator/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/validator/tasks/main.yaml
@@ -19,7 +19,7 @@
 # This task gets the genesis file when there isno local genesis
 - name: get genesis from vault
   shell: |
-    vault kv get -field=genesis secret/{{ component_ns }}/crypto/genesis
+    vault kv get -field=genesis {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/genesis
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/create/validator/tasks/nested_enode_data.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/create/validator/tasks/nested_enode_data.yaml
@@ -16,7 +16,7 @@
 # Fetch nodekey from vault
 - name: Get the nodekey from vault and generate the enode
   shell: |
-    vault read -field=key.pub secret/{{ org.name }}-bes/crypto/{{ peer.name }}/data | sed -r 's/^.{2}//' > {{ build_path }}/{{ org.name }}/{{ peer.name }}/enode
+    vault read -field=key.pub {{ vault.secret_path | default('secret') }}/{{ org.name }}-bes/crypto/{{ peer.name }}/data | sed -r 's/^.{2}//' > {{ build_path }}/{{ org.name }}/{{ peer.name }}/enode
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-besu/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -38,12 +38,12 @@
 # This task deletes crypto material
 - name: Delete Crypto material 
   shell: |
-    vault delete secret/{{ org_namespace }}/crypto/{{ peer.name }}/data
-    vault delete secret/{{ org_namespace }}/crypto/{{ peer.name }}/orion
-    vault delete secret/{{ org_namespace }}/crypto/{{ peer.name }}/certs
-    vault delete secret/{{ org_namespace }}/crypto/{{ peer.name }}/tls
-    vault delete secret/{{ org_namespace }}/crypto/genesis
-    vault delete secret/besu-{{ network.env.type }}/rootca
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/{{ peer.name }}/data
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/{{ peer.name }}/orion
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/{{ peer.name }}/certs
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/{{ peer.name }}/tls
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/genesis
+    vault delete {{ item.vault.secret_path | default('secret') }}/besu-{{ network.env.type }}/rootca
   loop: "{{ services.peers is defined | ternary( services.peers, services.validators) }}"
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"

--- a/platforms/hyperledger-besu/configuration/roles/helm_component/templates/node_orion.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/helm_component/templates/node_orion.tpl
@@ -75,7 +75,7 @@ spec:
 
     vault:
       address: {{ vault.url }}
-      secretprefix: secret/{{ component_ns }}/crypto/{{ peer.name }}
+      secretprefix: {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}
       serviceaccountname: vault-auth
       keyname: data
       oriondir: orion

--- a/platforms/hyperledger-besu/configuration/roles/helm_component/templates/validator.tpl
+++ b/platforms/hyperledger-besu/configuration/roles/helm_component/templates/validator.tpl
@@ -61,7 +61,7 @@ spec:
 
     vault:
       address: {{ vault.url }}
-      secretprefix: secret/{{ component_ns }}/crypto/{{ peer.name }}
+      secretprefix: {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}
       serviceaccountname: vault-auth
       keyname: data
       tlsdir: tls

--- a/platforms/hyperledger-besu/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/hyperledger-besu/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -86,10 +86,10 @@
 - name: Create policy for Access Control
   shell: |
     cd ./build    
-    echo "path \"secret/{{ component_ns }}/crypto/*\" {
+    echo "path \"{{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/*\" {
         capabilities = [\"read\", \"list\"]
     }
-    path \"secret/{{ component_ns }}/smartContracts/*\" {
+    path \"{{ vault.secret_path | default('secret') }}/{{ component_ns }}/smartContracts/*\" {
         capabilities = [\"read\", \"list\"]
     }"  >>  vault-crypto-{{ component_type }}-{{ component_name }}-ro.hcl
     vault write sys/policy/vault-crypto-{{ component_type }}-{{ component_name }}-ro policy="@vault-crypto-{{ component_type }}-{{ component_name }}-ro.hcl"  

--- a/platforms/hyperledger-besu/configuration/samples/network-besu-newnode.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu-newnode.yaml
@@ -89,6 +89,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
@@ -70,6 +70,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -154,6 +155,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -213,6 +215,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -272,6 +275,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -330,6 +334,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-fabric/configuration/roles/create/ca-server/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/ca-server/tasks/main.yaml
@@ -5,7 +5,7 @@
 
 - name: Check if ca certs already created
   shell: |
-    vault kv get -field=ca.{{ component_name }}-cert.pem secret/crypto/{{ component_type }}Organizations/{{ component_name }}/ca
+    vault kv get -field=ca.{{ component_name }}-cert.pem {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ca
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -24,9 +24,9 @@
 
 - name: Get ca certs and key
   shell: |
-    vault kv get -field=ca.{{ component_name }}-cert.pem secret/crypto/{{ component_type }}Organizations/{{ component_name }}/ca > ca.{{ component_name }}-cert.pem
+    vault kv get -field=ca.{{ component_name }}-cert.pem {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ca > ca.{{ component_name }}-cert.pem
     mv ca.{{ component_name }}-cert.pem ./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca/
-    vault kv get -field={{ component_name }}-CA.key secret/crypto/{{ component_type }}Organizations/{{ component_name }}/ca > {{ component_name }}-CA.key
+    vault kv get -field={{ component_name }}-CA.key {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ca > {{ component_name }}-CA.key
     mv {{ component_name }}-CA.key ./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca/
   environment:
     VAULT_ADDR: "{{ vault.url }}"
@@ -54,7 +54,7 @@
 # This task copy the CA certificates generated above, to the Vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault write secret/crypto/{{ component_type }}Organizations/{{ component_name }}/ca ca.{{ component_name }}-cert.pem="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca/ca.{{ component_name }}-cert.pem")" {{ component_name }}-CA.key="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca/{{ component_name }}-CA.key")"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ca ca.{{ component_name }}-cert.pem="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca/ca.{{ component_name }}-cert.pem")" {{ component_name }}-CA.key="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/ca/{{ component_name }}-CA.key")"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -64,7 +64,7 @@
 
 - name: Check if ca admin credentials already created
   shell: |
-    vault kv get secret/credentials/{{ component_name }}/ca/{{ component }}
+    vault kv get {{ vault.secret_path | default('secret') }}/credentials/{{ component_name }}/ca/{{ component }}
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -76,7 +76,7 @@
 # This task write the CA server admin credentials to Vault
 - name: Write the ca server admin credentials to Vault
   shell: |
-    vault write secret/credentials/{{ component_name }}/ca/{{ component }} user="{{ component }}-adminpw"
+    vault write {{ vault.secret_path | default('secret') }}/credentials/{{ component_name }}/ca/{{ component }} user="{{ component }}-adminpw"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/chaincode/install/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/chaincode/install/tasks/valuefile.yaml
@@ -30,7 +30,7 @@
 # This task write the git credentials to Vault
 - name: Write the git credentials to Vault
   shell: |
-    vault write secret/credentials/{{ namespace }}/git git_password="{{ peer.chaincode.repository.password }}"
+    vault write {{ vault.secret_path | default('secret') }}/credentials/{{ namespace }}/git git_password="{{ peer.chaincode.repository.password }}"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/main.yaml
@@ -5,7 +5,7 @@
 # Check admin msp already created
 - name: Check if admin msp already created
   shell: |
-    vault kv get -field=admincerts secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
+    vault kv get -field=admincerts {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -30,7 +30,7 @@
 # Check admin msp already created
 - name: Check if admin msp already created
   shell: |
-    vault kv get -field=admincerts secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
+    vault kv get -field=admincerts {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -40,8 +40,8 @@
 
 - name: Copy organization level certificates for orgs
   shell: |
-    vault write secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/tls ca.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)" client.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.crt)" client.key="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.key)"
-    vault write secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp admincerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/users/admin/tls ca.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)" client.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.crt)" client.key="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.key)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp admincerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/orderer.yaml
@@ -1,7 +1,7 @@
 # Check orderer msp already created
 - name: Check if orderer msp already created
   shell: |
-    vault kv get -format=yaml secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -25,7 +25,7 @@
 
 - name: Check if orderer tls already created
   shell: |
-    vault kv get -field=ca.crt secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls
+    vault kv get -field=ca.crt {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -44,8 +44,8 @@
 
 - name: Get Orderer tls crt
   shell: |
-    vault kv get -field=ca.crt secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls > ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/ca.crt
-    vault kv get -field=server.crt secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls > ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/server.crt
+    vault kv get -field=ca.crt {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls > ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/ca.crt
+    vault kv get -field=server.crt {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls > ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/server.crt
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -133,8 +133,8 @@
 # These roles put the above created crypto material in the vault
 - name: Copy the crypto material for orderer
   shell: |
-    vault write secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls ca.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/ca.crt)" server.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/server.crt)" server.key="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/server.key)"
-    vault write secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp admincerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/tlscacerts/ca-{{ component_name }}-7054.pem)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls ca.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/ca.crt)" server.crt="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/server.crt)" server.key="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls/server.key)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp admincerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp/tlscacerts/ca-{{ component_name }}-7054.pem)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -156,7 +156,7 @@
  #Check the existence of Orderer ambassador certs secret in the vault 
 - name: Check if orderer ambassador secrets already created
   shell: |
-    vault kv get -format=yaml secret/crypto/{{ component_type }}Organizations/{{ component_name }}/ambassador/{{ orderer.name }}
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ambassador/{{ orderer.name }}
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -199,7 +199,7 @@
  # This task copy the orderer certificates generated above, to the Vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault write secret/crypto/{{ component_type }}Organizations/{{ component_name }}/ambassador/{{ orderer.name }} certificate="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{orderer.name}}-{{ component_name }}-certchain.pem")" key="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ orderer.name }}-{{ component_name }}.key")"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ambassador/{{ orderer.name }} certificate="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{orderer.name}}-{{ component_name }}-certchain.pem")" key="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ orderer.name }}-{{ component_name }}.key")"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/orderercheck.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/orderercheck.yaml
@@ -21,7 +21,7 @@
 # Check if CA certs exists in vault, if not this should fail. If yes, get the certificate
 - name: Check if ca certs already created
   shell: |
-    vault kv get -field=ca.{{ component_name }}-cert.pem secret/crypto/ordererOrganizations/{{ component_name }}/ca > ca.{{ component_name }}-cert.pem
+    vault kv get -field=ca.{{ component_name }}-cert.pem {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/ca > ca.{{ component_name }}-cert.pem
     mv ca.{{ component_name }}-cert.pem ./build/crypto-config/ordererOrganizations/{{ component_name }}/ca/
   environment:
     VAULT_ADDR: "{{ vault.url }}"
@@ -31,7 +31,7 @@
 # Check if CA key exists in vault, if not this should fail. If yes, get the certificate
 - name: Check if ca key already created
   shell: |
-    vault kv get -field={{ component_name }}-CA.key secret/crypto/ordererOrganizations/{{ component_name }}/ca > {{ component_name }}-CA.key
+    vault kv get -field={{ component_name }}-CA.key {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/ca > {{ component_name }}-CA.key
     mv {{ component_name }}-CA.key ./build/crypto-config/ordererOrganizations/{{ component_name }}/ca/
   environment:
     VAULT_ADDR: "{{ vault.url }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/main.yaml
@@ -27,7 +27,7 @@
 # Check if CA certs exists in vault, if not this should fail. If yes, get the certificate
 - name: Check if ca certs already created
   shell: |
-    vault kv get -field=ca.{{ component_name }}-cert.pem secret/crypto/peerOrganizations/{{ component_name }}/ca > ca.{{ component_name }}-cert.pem
+    vault kv get -field=ca.{{ component_name }}-cert.pem {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/ca > ca.{{ component_name }}-cert.pem
     mv ca.{{ component_name }}-cert.pem ./build/crypto-config/peerOrganizations/{{ component_name }}/ca/
   environment:
     VAULT_ADDR: "{{ vault.url }}"
@@ -37,7 +37,7 @@
 # Check if CA key exists in vault, if not this should fail. If yes, get the certificate
 - name: Check if ca key already created
   shell: |
-    vault kv get -field={{ component_name }}-CA.key secret/crypto/peerOrganizations/{{ component_name }}/ca > {{ component_name }}-CA.key
+    vault kv get -field={{ component_name }}-CA.key {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/ca > {{ component_name }}-CA.key
     mv {{ component_name }}-CA.key ./build/crypto-config/peerOrganizations/{{ component_name }}/ca/
   environment:
     VAULT_ADDR: "{{ vault.url }}"
@@ -133,7 +133,7 @@
 # Check if Orderer certs exists in vault. If yes, get the certificate
 - name: Check if Orderer certs exist in Vault
   shell: |
-    vault kv get -field=ca.crt secret/crypto/peerOrganizations/{{ component_name }}/orderer/tls
+    vault kv get -field=ca.crt {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/orderer/tls
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -158,7 +158,7 @@
 - name: Copy organization level certificates for orderers
   shell: |
     {% for orderer in orderers %}
-    vault write secret/crypto/peerOrganizations/{{ component_name }}/orderer/tls ca.crt="$(cat {{ orderer.certificate }})" 
+    vault write {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/orderer/tls ca.crt="$(cat {{ orderer.certificate }})" 
     {% endfor %}
   vars:
     orderers: "{{ network.orderers }}"
@@ -172,7 +172,7 @@
 # Check admin msp already created
 - name: Check if admin msp already created
   shell: |
-    vault kv get -field=admincerts secret/crypto/peerOrganizations/{{ component_name }}/users/admin/msp
+    vault kv get -field=admincerts {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/admin/msp
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -182,8 +182,8 @@
 
 - name: Copy organization level certificates for orgs
   shell: |
-    vault write secret/crypto/peerOrganizations/{{ component_name }}/users/admin/tls ca.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)" client.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.crt)" client.key="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.key)"
-    vault write secret/crypto/peerOrganizations/{{ component_name }}/users/admin/msp admincerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/admin/tls ca.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)" client.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.crt)" client.key="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/client.key)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/admin/msp admincerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/Admin@{{ component_name }}/tls/ca.crt)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -192,7 +192,7 @@
 # Check user msp already created
 - name: Check if user msp already created
   shell: |
-    vault kv get -field=admincerts secret/crypto/peerOrganizations/{{ component_name }}/users/user1/msp
+    vault kv get -field=admincerts {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/user1/msp
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -202,8 +202,8 @@
 
 - name: Copy user certificates for orgs
   shell: |
-    vault write secret/crypto/peerOrganizations/{{ component_name }}/users/user1/tls ca.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/ca.crt)" client.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/client.crt)" client.key="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/client.key)"
-    vault write secret/crypto/peerOrganizations/{{ component_name }}/users/user1/msp admincerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/admincerts/User1@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/ca.crt)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/user1/tls ca.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/ca.crt)" client.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/client.crt)" client.key="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/client.key)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/user1/msp admincerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/admincerts/User1@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/users/User1@{{ component_name }}/tls/ca.crt)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/peer.yaml
@@ -1,8 +1,8 @@
 # Copy the crypto material for orgs
 - name: Copy the crypto material for orgs
   shell: |
-    vault write secret/crypto/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls ca.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls/ca.crt)" server.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls/server.crt)" server.key="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls/server.key)"
-    vault write secret/crypto/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp admincerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/tlscacerts/ca-{{ component_name }}-7054.pem)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls ca.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls/ca.crt)" server.crt="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls/server.crt)" server.key="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/tls/server.key)"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp admincerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/admincerts/Admin@{{ component_name }}-cert.pem)" cacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/cacerts/ca-{{ component_name }}-7054.pem)" keystore="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/keystore/*_sk)" signcerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/signcerts/cert.pem)" tlscacerts="$(cat ./build/crypto-config/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp/tlscacerts/ca-{{ component_name }}-7054.pem)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -32,7 +32,7 @@
  #Check the existence of Peer ambassador certs secret in the vault 
 - name: Check if peer ambassador secrets certs created
   shell: |
-    vault kv get -format=yaml secret/crypto/peerOrganizations/{{ component_name }}/ambassador
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/ambassador
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -114,7 +114,7 @@
  # This task copy the peer certificates generated above, to the Vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault write secret/crypto/{{ component_type }}Organizations/{{ component_name }}/ambassador clientcert="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ peer.name }}-{{ component_name }}.pem")" certificate="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ peer.name }}-{{ component_name }}-certchain.pem")" key="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ peer.name }}-{{ component_name }}.key")"
+    vault write {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component_name }}/ambassador clientcert="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ peer.name }}-{{ component_name }}.pem")" certificate="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ peer.name }}-{{ component_name }}-certchain.pem")" key="$(cat "./build/crypto-config/{{ component_type }}Organizations/{{ component_name }}/{{ peer.name }}-{{ component_name }}.key")"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/peercheck.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/peercheck.yaml
@@ -1,7 +1,7 @@
 # Check peer msp already created
 - name: Check if peer msp already created
   shell: |
-    vault kv get -format=yaml secret/crypto/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/peers/{{ peer.name }}.{{ component_name }}/msp
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
@@ -16,7 +16,7 @@
 
 - name: "Write genesis block to Vault"  
   shell: |
-    vault write secret/crypto/ordererOrganizations genesisBlock="$(cat {{build_path}}/channel-artifacts/genesis.block.base64)"
+    vault write {{ org.vault.secret_path | default('secret') }}/crypto/ordererOrganizations genesisBlock="$(cat {{build_path}}/channel-artifacts/genesis.block.base64)"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_syschannel_block/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_orderer/create_syschannel_block/tasks/main.yaml
@@ -106,7 +106,7 @@
 # add new genesis block to the vault
 - name: "Write genesis block to Vault"  
   shell: |
-    vault write secret/crypto/ordererOrganizations genesisBlock="$(cat {{build_path}}/channel-artifacts/genesis.block.base64)"
+    vault write {{ org.vault.secret_path | default('secret') }}/crypto/ordererOrganizations genesisBlock="$(cat {{build_path}}/channel-artifacts/genesis.block.base64)"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/peers/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/peers/tasks/main.yaml
@@ -7,7 +7,7 @@
 # This task writes the couchdb credentials for each organization to the vault
 - name: Write the couchdb credentials to Vault
   shell: |
-    vault write secret/credentials/{{ namespace }}/couchdb/{{ item.name | lower}} user="admin123"
+    vault write {{ vault.secret_path | default('secret') }}/credentials/{{ namespace }}/couchdb/{{ item.name | lower}} user="admin123"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/delete/genesis/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/genesis/tasks/main.yaml
@@ -5,7 +5,7 @@
 # This task deletes the BASE 64 encoded genesis blocks for all channels
 - name: Delete genesis block from Vault
   shell: |
-    vault delete secret/crypto/ordererOrganizations
+    vault delete {{ org.vault.secret_path | default('secret') }}/crypto/ordererOrganizations
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -80,13 +80,13 @@
 # This task deletes crypto materials from vault
 - name: Delete Crypto for orderers
   shell: |
-    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/ca
-    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls
-    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp
-    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/tls
-    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
-    vault delete secret/crypto/ordererOrganizations/{{ component_name }}/ambassador/{{orderer.name}}
-    vault delete secret/credentials/{{ component_name }}/ca/{{ org_name }}
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/ca
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/tls
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/orderers/{{orderer.name}}.{{ component_name }}/msp
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/users/admin/tls
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/users/admin/msp
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name }}/ambassador/{{orderer.name}}
+    vault delete {{ item.vault.secret_path | default('secret') }}/credentials/{{ component_name }}/ca/{{ org_name }}
   loop: "{{ services.orderers }}"
   loop_control:
     loop_var: orderer
@@ -99,20 +99,20 @@
 # This task deletes crypto materials from vault
 - name: Delete Crypto for peers
   shell: |
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/ca
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/users/admin/tls
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/users/admin/msp
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/users/user1/tls
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/users/user1/msp
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/orderer/tls
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/ambassador
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/ca
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/admin/tls
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/admin/msp
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/user1/tls
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/users/user1/msp
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/orderer/tls
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/ambassador
     {% for peer in peers %}
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/peers/{{peer.name}}.{{ component_name }}/tls
-    vault delete secret/crypto/peerOrganizations/{{ component_name }}/peers/{{peer.name}}.{{ component_name }}/msp
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/peers/{{peer.name}}.{{ component_name }}/tls
+    vault delete {{ item.vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name }}/peers/{{peer.name}}.{{ component_name }}/msp
     {% endfor %}
-    vault delete secret/credentials/{{ component_name }}/ca/{{ org_name }}
-    vault delete secret/credentials/{{ component_name }}/couchdb/{{ org_name }}
-    vault delete secret/credentials/{{ component_name }}/git
+    vault delete {{ item.vault.secret_path | default('secret') }}/credentials/{{ component_name }}/ca/{{ org_name }}
+    vault delete {{ item.vault.secret_path | default('secret') }}/credentials/{{ component_name }}/couchdb/{{ org_name }}
+    vault delete {{ item.vault.secret_path | default('secret') }}/credentials/{{ component_name }}/git
   vars:
     peers: "{{ services.peers }}"
   environment:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/anchorpeer_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/anchorpeer_job.tpl
@@ -33,8 +33,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ component_ns }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/users/admin
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/orderer
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/users/admin
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
 

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-orderer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-orderer.tpl
@@ -28,9 +28,9 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ component_name }}-auth
-      secretcert: secret/crypto/ordererOrganizations/{{ component_name | e }}/ca?ca.{{ component_name | e }}-cert.pem
-      secretkey: secret/crypto/ordererOrganizations/{{ component_name | e }}/ca?{{ component_name | e }}-CA.key
-      secretadminpass: secret/credentials/{{ component_name | e }}/ca/{{ component }}?user
+      secretcert: {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name | e }}/ca?ca.{{ component_name | e }}-cert.pem
+      secretkey: {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_name | e }}/ca?{{ component_name | e }}-CA.key
+      secretadminpass: {{ vault.secret_path | default('secret') }}/credentials/{{ component_name | e }}/ca/{{ component }}?user
       serviceaccountname: vault-auth
       imagesecretname: regcred
     service:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca-peer.tpl
@@ -28,9 +28,9 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ component_name | e }}-auth
-      secretcert: secret/crypto/peerOrganizations/{{ component_name | e }}/ca?ca.{{ component_name | e }}-cert.pem
-      secretkey: secret/crypto/peerOrganizations/{{ component_name | e }}/ca?{{ component_name | e }}-CA.key
-      secretadminpass: secret/credentials/{{ component_name | e }}/ca/{{ component }}?user
+      secretcert: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name | e }}/ca?ca.{{ component_name | e }}-cert.pem
+      secretkey: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_name | e }}/ca?{{ component_name | e }}-CA.key
+      secretadminpass: {{ vault.secret_path | default('secret') }}/credentials/{{ component_name | e }}/ca/{{ component }}?user
       serviceaccountname: vault-auth
       imagesecretname: regcred
     service:

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cli.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/cli.tpl
@@ -24,8 +24,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ component_ns }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/users/admin
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/orderer
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/users/admin
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
       tls: false

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
@@ -28,8 +28,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ component_ns }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/users/admin
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/orderer 
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/users/admin
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/orderer 
       serviceaccountname: vault-auth
       imagesecretname: regcred
 

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
@@ -27,11 +27,11 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ namespace | e }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/users/admin 
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/orderer
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/users/admin 
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
-      secretgitprivatekey: secret/credentials/{{ namespace }}/git?git_password
+      secretgitprivatekey: {{ vault.secret_path | default('secret') }}/credentials/{{ namespace }}/git?git_password
       tls: false
     orderer:
       address: {{ orderer_address }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/instantiate_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/instantiate_chaincode_job.tpl
@@ -27,8 +27,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ namespace | e }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/users/admin 
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/orderer
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/users/admin 
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
       tls: false

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
@@ -27,8 +27,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ namespace | e }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/users/admin 
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/orderer
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/users/admin 
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
       tls: false

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/join_channel_job.tpl
@@ -33,8 +33,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ component_ns }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/users/admin
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/orderer
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/users/admin
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
 

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/orderernode.tpl
@@ -45,7 +45,7 @@ spec:
       address: {{ vault.url }}
       role: vault-role
       authpath: {{ namespace }}-auth
-      secretprefix: secret/crypto/ordererOrganizations/{{ namespace }}/orderers/{{ orderer.name }}.{{ namespace }}
+      secretprefix: {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ namespace }}/orderers/{{ orderer.name }}.{{ namespace }}
       imagesecretname: regcred
       serviceaccountname: vault-auth
 {% if orderer.consensus == 'kafka' %}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/upgrade_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/upgrade_chaincode_job.tpl
@@ -27,8 +27,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ namespace | e }}-auth
-      adminsecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/users/admin 
-      orderersecretprefix: secret/crypto/peerOrganizations/{{ namespace }}/orderer
+      adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/users/admin 
+      orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
       tls: false

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
@@ -46,11 +46,11 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ namespace }}-auth
-      secretprefix: secret/crypto/peerOrganizations/{{ namespace }}/peers/{{ peer_name }}.{{ namespace }}
-      secretambassador: secret/crypto/peerOrganizations/{{ namespace }}/ambassador
+      secretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/peers/{{ peer_name }}.{{ namespace }}
+      secretambassador: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/ambassador
       serviceaccountname: vault-auth
       imagesecretname: regcred
-      secretcouchdbpass: secret/credentials/{{ namespace }}/couchdb/{{ name }}?user
+      secretcouchdbpass: {{ vault.secret_path | default('secret') }}/credentials/{{ namespace }}/couchdb/{{ name }}?user
 
     service:
       servicetype: ClusterIP

--- a/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/existing_peer_cli.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/existing_peer_cli.tpl
@@ -10,8 +10,8 @@ vault:
   role: vault-role
   address: {{ vault.url }}
   authpath: {{ component_ns }}-auth
-  adminsecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/users/admin
-  orderersecretprefix: secret/crypto/peerOrganizations/{{ component_ns }}/orderer
+  adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/users/admin
+  orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ component_ns }}/orderer
   serviceaccountname: vault-auth
   imagesecretname: regcred
   tls: false

--- a/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/orderer_cli.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/k8_component/templates/orderer_cli.tpl
@@ -10,8 +10,8 @@ vault:
   role: vault-role
   address: {{ vault.url }}
   authpath: {{ component_ns }}-auth
-  adminsecretprefix: secret/crypto/ordererOrganizations/{{ component_ns }}/users/admin
-  orderersecretprefix: secret/crypto/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer_component }}
+  adminsecretprefix: {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_ns }}/users/admin
+  orderersecretprefix: {{ vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ component_ns }}/orderers/{{ orderer_component }}
   serviceaccountname: vault-auth
   imagesecretname: regcred
   tls: false

--- a/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -93,6 +93,7 @@
     dest: "./build/vault-crypto-{{ component_name | lower }}-ro.hcl"
   vars:
     component_name: "{{ component_name }}"
+    vault_secret_path: "{{ vault.secret_path | default('secret') }}"
   when: component_type == 'orderer' and vault_policy_result.failed == True  # Run if policy check failed
 
 
@@ -104,6 +105,7 @@
     dest: "./build/vault-crypto-{{ component_name | lower }}-ro.hcl"
   vars:
     component_name: "{{ component_name }}"
+    vault_secret_path: "{{ vault.secret_path | default('secret') }}"
   when: component_type == 'peer' and vault_policy_result.failed == True   # Run if policy check failed
 
 

--- a/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/templates/orderer-ro.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/templates/orderer-ro.tpl
@@ -1,12 +1,12 @@
-path "secret/crypto/ordererOrganizations/{{ component_name }}/*" {
+path "{{ vault_secret_path }}/crypto/ordererOrganizations/{{ component_name }}/*" {
     capabilities = ["read", "list"]
 }
-path "secret/*" {
+path "{{ vault_secret_path }}/*" {
     capabilities = ["list"]
 }
-path "secret/crypto/peerOrganizations/*" {
+path "{{ vault_secret_path }}/crypto/peerOrganizations/*" {
     capabilities = ["deny"]
 }
-path "secret/credentials/{{ component_name }}/*" {
+path "{{ vault_secret_path }}/credentials/{{ component_name }}/*" {
     capabilities = ["read", "list"]
 }

--- a/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/templates/peer-ro.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/vault_kubernetes/templates/peer-ro.tpl
@@ -1,18 +1,18 @@
-path "secret/*" {
+path "{{ vault_secret_path }}/*" {
     capabilities = ["list"]
 }
-path "secret/crypto/ordererOrganizations/*" {
+path "{{ vault_secret_path }}/crypto/ordererOrganizations/*" {
     capabilities = ["deny"]
 }
-path "secret/credentials/{{ component_name }}/*" {
+path "{{ vault_secret_path }}/credentials/{{ component_name }}/*" {
     capabilities = ["read", "list"]
 }
-path "secret/crypto/peerOrganizations" {
+path "{{ vault_secret_path }}/crypto/peerOrganizations" {
 capabilities = ["deny"]
 }
-path "secret/crypto/peerOrganizations/*" {
+path "{{ vault_secret_path }}/crypto/peerOrganizations/*" {
 capabilities = ["deny"]
 }
-path "secret/crypto/peerOrganizations/{{ component_name }}/*" {
+path "{{ vault_secret_path }}/crypto/peerOrganizations/{{ component_name }}/*" {
     capabilities = ["read", "list"]
 }

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
@@ -182,7 +182,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -269,7 +269,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -357,7 +357,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -442,7 +442,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -534,7 +534,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
@@ -126,7 +126,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -205,7 +205,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -290,7 +290,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -372,7 +372,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -461,7 +461,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv-add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv-add-peer.yaml
@@ -102,7 +102,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -179,7 +179,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
@@ -139,7 +139,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
@@ -133,7 +133,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -219,7 +219,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -304,7 +304,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -386,7 +386,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -475,7 +475,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -126,7 +126,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -205,7 +205,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -290,7 +290,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -372,7 +372,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -460,7 +460,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-fabric/configuration/samples/network-minikube.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-minikube.yaml
@@ -95,7 +95,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -164,7 +164,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -246,7 +246,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-indy/configuration/samples/network-indyv3-aries.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-indyv3-aries.yaml
@@ -64,7 +64,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -116,7 +116,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-indy/configuration/samples/network-indyv3.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-indyv3.yaml
@@ -67,7 +67,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -119,7 +119,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -206,7 +206,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-indy/configuration/samples/network-minikube-aries.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-minikube-aries.yaml
@@ -51,7 +51,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -94,7 +94,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/hyperledger-indy/configuration/samples/network-minikube.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-minikube.yaml
@@ -48,7 +48,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -91,7 +91,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -165,7 +165,7 @@ network:
       vault:
         url: "vault_url"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/quorum/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
+++ b/platforms/quorum/configuration/roles/create/certificates/ambassador/tasks/nested_main.yaml
@@ -21,7 +21,7 @@
 # Checks if certificates for root are already created and stored in vault.
 - name: Check if certs already created
   shell: |
-    vault kv get -format=yaml secret/{{ component_ns }}/crypto/{{ node_name }}/certs
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ node_name }}/certs
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -60,7 +60,7 @@
 # Check ambassador tls certs already created
 - name: Check if ambassador tls already created
   shell: |
-    vault kv get -format=yaml secret/{{ component_ns }}/crypto/{{ node_name }}/certs
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ node_name }}/certs
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -129,7 +129,7 @@
 - name: Putting certs to vault
   shell: |
     cd {{ rootca }}
-    vault kv put secret/{{component_ns}}/crypto/{{node_name}}/certs \
+    vault kv put {{ vault.secret_path | default('secret') }}/{{component_ns}}/crypto/{{node_name}}/certs \
     rootcacertpkcs12="$(cat {{rootca}}/rootcacert.pkcs12 | base64)" \
     rootcakeypkcs12="$(cat {{rootca}}/rootcakey.pkcs12 | base64)" \
     rootcapem="$(cat {{rootca}}/rootca.pem | base64)" \

--- a/platforms/quorum/configuration/roles/create/constellation/tasks/nested_enode_data.yaml
+++ b/platforms/quorum/configuration/roles/create/constellation/tasks/nested_enode_data.yaml
@@ -16,7 +16,7 @@
 # Fetch nodekey from vault
 - name: Get the nodekey from vault and generate the enode
   shell: |
-    vault read -field=nodekey secret/{{ org.name }}-quo/crypto/{{ peer.name }}/quorum > {{ build_path }}/{{ org.name }}/{{ peer.name }}/nodekey
+    vault read -field=nodekey {{ vault.secret_path | default('secret') }}/{{ org.name }}-quo/crypto/{{ peer.name }}/quorum > {{ build_path }}/{{ org.name }}/{{ peer.name }}/nodekey
     bootnode --nodekey={{ build_path }}/{{ org.name }}/{{ peer.name }}/nodekey --writeaddress > {{ build_path }}/{{ org.name }}/{{ peer.name }}/enode
   environment:
     VAULT_ADDR: "{{ vault.url }}"

--- a/platforms/quorum/configuration/roles/create/crypto/constellation/tasks/nested_main.yaml
+++ b/platforms/quorum/configuration/roles/create/crypto/constellation/tasks/nested_main.yaml
@@ -1,7 +1,7 @@
 # This tasks checks if transaction manager key is already present in the vault
 - name: Check tm key is present the vault
   shell: |
-    vault read -field=tm.pub secret/{{ component_ns }}/crypto/{{ node.name }}/transaction
+    vault read -field=tm.pub {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ node.name }}/transaction
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -25,7 +25,7 @@
 
 - name: Copy the crypto into vault
   shell: |
-    vault kv put secret/{{component_ns}}/crypto/{{ node.name }}/transaction tm.pub="$(cat build/{{ component_name }}/{{ node.name }}/tm.pub)" tm.key="$(cat build/{{ component_name }}/{{ node.name }}/tm.key)"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{component_ns}}/crypto/{{ node.name }}/transaction tm.pub="$(cat build/{{ component_name }}/{{ node.name }}/tm.pub)" tm.key="$(cat build/{{ component_name }}/{{ node.name }}/tm.key)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/quorum/configuration/roles/create/crypto/ibft/tasks/nested_main.yaml
+++ b/platforms/quorum/configuration/roles/create/crypto/ibft/tasks/nested_main.yaml
@@ -1,7 +1,7 @@
 # This task checks if the crypto material is already stored in the vault or not
 - name: Check if nodekey already present in the vault
   shell: |
-    vault read -field=nodekey secret/{{ component_ns }}/crypto/{{ peer.name }}/quorum
+    vault read -field=nodekey {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/quorum
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -28,7 +28,7 @@
 # This tasks copy the crypto material to the vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault kv put secret/{{ component_ns }}/crypto/{{ peer.name }}/quorum nodekey="$(cat build/{{ component_name }}/{{ peer.name }}/nodekey)" keystore="$(cat build/{{ component_name }}/{{ peer.name }}/keystore.json)" db_user="demouser" db_password="password" gethpassword="$(cat build/{{ component_name }}/{{ peer.name }}/password)"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/quorum nodekey="$(cat build/{{ component_name }}/{{ peer.name }}/nodekey)" keystore="$(cat build/{{ component_name }}/{{ peer.name }}/keystore.json)" db_user="demouser" db_password="password" gethpassword="$(cat build/{{ component_name }}/{{ peer.name }}/password)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/quorum/configuration/roles/create/crypto/raft/tasks/nested_main.yaml
+++ b/platforms/quorum/configuration/roles/create/crypto/raft/tasks/nested_main.yaml
@@ -1,7 +1,7 @@
 # This task checks if the crypto material is already stored in the vault or not
 - name: Check if nodekey already present in the vault
   shell: |
-    vault read -field=nodekey secret/{{ component_ns }}/crypto/{{ peer.name }}/quorum
+    vault read -field=nodekey {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/quorum
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -30,7 +30,7 @@
 # This tasks copy the crypto material to the vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault kv put secret/{{ component_ns }}/crypto/{{ peer.name }}/quorum nodekey="$(cat build/{{ component_name}}/{{ peer.name }}/nodekey)" keystore="$(cat build/{{ component_name }}/{{ peer.name }}/keystore.json)" db_user="demouser" db_password="password" gethpassword="$(cat build/{{ component_name }}/{{ peer.name }}/password)"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/quorum nodekey="$(cat build/{{ component_name}}/{{ peer.name }}/nodekey)" keystore="$(cat build/{{ component_name }}/{{ peer.name }}/keystore.json)" db_user="demouser" db_password="password" gethpassword="$(cat build/{{ component_name }}/{{ peer.name }}/password)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/quorum/configuration/roles/create/crypto/tessera/tasks/nested_main.yaml
+++ b/platforms/quorum/configuration/roles/create/crypto/tessera/tasks/nested_main.yaml
@@ -1,7 +1,7 @@
 # This task checks if the tm crypto material is already stored in the vault or not
 - name: Check if tm key is already present in the vault
   shell: |
-    vault read -field=tm.key secret/{{ component_ns }}/crypto/{{ peer.name }}/transaction
+    vault read -field=tm.key {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/transaction
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
@@ -41,7 +41,7 @@
 # This task copies the crypto material to the vault
 - name: Copy the crypto material to Vault
   shell: |
-    vault kv put secret/{{ component_ns }}/crypto/{{ peer.name }}/transaction tm.pub="$(cat build/{{ component_name }}/{{ peer.name }}/tm.pub)" tm.key="$(cat build/{{ component_name }}/{{ peer.name }}/tm.key)"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/transaction tm.pub="$(cat build/{{ component_name }}/{{ peer.name }}/tm.pub)" tm.key="$(cat build/{{ component_name }}/{{ peer.name }}/tm.key)"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/quorum/configuration/roles/create/genesis_nodekey/tasks/nested_nodekey_vault_check.yaml
+++ b/platforms/quorum/configuration/roles/create/genesis_nodekey/tasks/nested_nodekey_vault_check.yaml
@@ -1,7 +1,7 @@
 # This task checks if the crypto material is already stored in the vault or not
 - name: Check if nodekey already present in the vault
   shell: |
-    vault read -field=nodekey secret/{{ component_ns }}/crypto/{{ peer.name }}/quorum
+    vault read -field=nodekey {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}/quorum
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/quorum/configuration/roles/create/genesis_raft/tasks/nested_validator_node_data.yaml
+++ b/platforms/quorum/configuration/roles/create/genesis_raft/tasks/nested_validator_node_data.yaml
@@ -16,7 +16,7 @@
 # Fetch keystore.json from vault
 - name: Get the keystore.json from vault
   shell: |
-    vault read -field=keystore secret/{{ org.name }}-quo/crypto/{{ peer.name }}/quorum > {{ build_path }}/{{ org.name }}/{{ peer.name }}/keystore.json
+    vault read -field=keystore {{ vault.secret_path | default('secret') }}/{{ org.name }}-quo/crypto/{{ peer.name }}/quorum > {{ build_path }}/{{ org.name }}/{{ peer.name }}/keystore.json
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/quorum/configuration/roles/create/tessera/tasks/nested_enode_data.yaml
+++ b/platforms/quorum/configuration/roles/create/tessera/tasks/nested_enode_data.yaml
@@ -16,7 +16,7 @@
 # Fetch nodekey from vault
 - name: Get the nodekey from vault and generate the enode
   shell: |
-    vault read -field=nodekey secret/{{ org.name }}-quo/crypto/{{ peer.name }}/quorum > {{ build_path }}/{{ org.name }}/{{ peer.name }}/nodekey
+    vault read -field=nodekey {{ vault.secret_path | default('secret') }}/{{ org.name }}-quo/crypto/{{ peer.name }}/quorum > {{ build_path }}/{{ org.name }}/{{ peer.name }}/nodekey
     bootnode --nodekey={{ build_path }}/{{ org.name }}/{{ peer.name }}/nodekey --writeaddress > {{ build_path }}/{{ org.name }}/{{ peer.name }}/enode
   environment:
     VAULT_ADDR: "{{ vault.url }}"

--- a/platforms/quorum/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -38,9 +38,9 @@
 # This task deletes crypto material
 - name: Delete Crypto material 
   shell: |
-    vault delete secret/{{ org_namespace }}/crypto/{{ peer.name }}/transaction
-    vault delete secret/{{ org_namespace }}/crypto/{{ peer.name }}/quorum
-    vault delete secret/{{ org_namespace }}/crypto/{{ peer.name }}/certs
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/{{ peer.name }}/transaction
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/{{ peer.name }}/quorum
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/crypto/{{ peer.name }}/certs
   loop: "{{ services.peers }}"
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"
@@ -52,7 +52,7 @@
   # This task deletes application crypto material
 - name: Delete Application Crypto material 
   shell: |
-    vault delete secret/{{ org_namespace }}/smartContracts/General
+    vault delete {{ item.vault.secret_path | default('secret') }}/{{ org_namespace }}/smartContracts/General
   loop: "{{ services.peers }}"
   environment:
     VAULT_ADDR: "{{ item.vault.url }}"

--- a/platforms/quorum/configuration/roles/helm_component/templates/constellation.tpl
+++ b/platforms/quorum/configuration/roles/helm_component/templates/constellation.tpl
@@ -43,7 +43,7 @@ spec:
         quorum: {{ peer.p2p.port }}
     vault:
       address: {{ vault.url }}
-      secretprefix: secret/{{ component_ns }}/crypto/{{ peer.name }}
+      secretprefix: {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}
       serviceaccountname: vault-auth
       keyname: quorum
       tm_keyname: transaction

--- a/platforms/quorum/configuration/roles/helm_component/templates/tessera.tpl
+++ b/platforms/quorum/configuration/roles/helm_component/templates/tessera.tpl
@@ -52,7 +52,7 @@ spec:
       mysqluser: demouser
     vault:
       address: {{ vault.url }}
-      secretprefix: secret/{{ component_ns }}/crypto/{{ peer.name }}
+      secretprefix: {{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/{{ peer.name }}
       serviceaccountname: vault-auth
       keyname: quorum
       tm_keyname: transaction

--- a/platforms/quorum/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -87,10 +87,10 @@
 - name: Create policy for Access Control
   shell: |
     cd ./build    
-    echo "path \"secret/{{ component_ns }}/crypto/*\" {
+    echo "path \"{{ vault.secret_path | default('secret') }}/{{ component_ns }}/crypto/*\" {
         capabilities = [\"read\", \"list\"]
     }
-    path \"secret/{{ component_ns }}/smartContracts/*\" {
+    path \"{{ vault.secret_path | default('secret') }}/{{ component_ns }}/smartContracts/*\" {
         capabilities = [\"read\", \"list\"]
     }"  >>  vault-crypto-{{ component_type }}-{{ component_name }}-ro.hcl
     vault write sys/policy/vault-crypto-{{ component_type }}-{{ component_name }}-ro policy="@vault-crypto-{{ component_type }}-{{ component_name }}-ro.hcl"

--- a/platforms/quorum/configuration/samples/network-quorum-newnode.yaml
+++ b/platforms/quorum/configuration/samples/network-quorum-newnode.yaml
@@ -90,6 +90,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/quorum/configuration/samples/network-quorum.yaml
+++ b/platforms/quorum/configuration/samples/network-quorum.yaml
@@ -79,6 +79,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -134,6 +135,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # IMPORTANT: Do not check-in your password, the git_access_token!
       gitops:
@@ -189,6 +191,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # IMPORTANT: Do not check-in your password, the git_access_token!
       gitops:
@@ -243,6 +246,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/r3-corda-ent/configuration/roles/create/certificates/cenm/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/certificates/cenm/tasks/main.yaml
@@ -21,7 +21,7 @@
 # Check if the ambassador tls is already created
 - name: Check if the Ambassador TLS is already created
   shell: |
-    vault kv get -format=yaml secret/{{ org.name | lower }}/{{ service_name }}/tlscerts
+    vault kv get -format=yaml {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ service_name }}/tlscerts
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -74,7 +74,7 @@
 # Store the ambassador certificates into the vault
 - name: Store the Ambassador certs to vault
   shell: |
-    vault kv put secret/{{ org.name | lower }}/{{ service_name }}/tlscerts tlscacerts="$(cat {{ tlscert_path }}/ambassador.pem | base64)" tlskey="$(cat {{ tlscert_path }}/ambassador.key | base64)"
+    vault kv put {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ service_name }}/tlscerts tlscacerts="$(cat {{ tlscert_path }}/ambassador.pem | base64)" tlskey="$(cat {{ tlscert_path }}/ambassador.key | base64)"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/create/certificates/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/certificates/node/tasks/main.yaml
@@ -20,7 +20,7 @@
 # Check if the ambassador tls is already created
 - name: Check if the Ambassador TLS is already created
   shell: |
-    vault kv get -format=yaml secret/{{ org.name | lower }}/{{ node_name }}/tlscerts
+    vault kv get -format=yaml {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ node_name }}/tlscerts
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -74,7 +74,7 @@
 # Store the ambassador certificates into the vault
 - name: Store the Ambassador certs to vault
   shell: |
-    vault kv put secret/{{ org.name | lower }}/{{ node_name }}/tlscerts tlscacerts="$(cat ./build/ambassador/{{ node_name }}/ambassador.pem | base64)" tlskey="$(cat ./build/ambassador/{{ node_name }}/ambassador.key | base64)"
+    vault kv put {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ node_name }}/tlscerts tlscacerts="$(cat ./build/ambassador/{{ node_name }}/ambassador.pem | base64)" tlskey="$(cat ./build/ambassador/{{ node_name }}/ambassador.key | base64)"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/delete/vault_secrets/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/delete/vault_secrets/tasks/main.yaml
@@ -79,7 +79,7 @@
 # This task deletes crypto materials from vault for cenm
 - name: Delete Crypto for CENM
   shell: |
-    vault secrets disable secret/{{ org.name | lower }}
+    vault secrets disable {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -87,23 +87,23 @@
 # This task deletes crypto material
 - name: Delete Crypto material for CENM
   shell: |
-    vault delete secret/{{ org.name | lower }}/root/certs
-    vault delete secret/{{ org.name | lower }}/{{ org.services.idman.name }}/certs
-    vault delete secret/{{ org.name | lower }}/{{ org.services.idman.name }}/crls
-    vault delete secret/{{ org.name | lower }}/{{ org.services.idman.name }}/tlscerts
-    vault delete secret/{{ org.name | lower }}/{{ org.services.notary.name }}/tlscerts
-    vault delete secret/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/nodekeystore
-    vault delete secret/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/sslkeystore
-    vault delete secret/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/truststore
-    vault delete secret/{{ org.name | lower }}/{{ org.services.notary.name }}/nodeInfo
-    vault delete secret/{{ org.name | lower }}/{{ org.services.notary.name }}/networkparam
-    vault delete secret/{{ org.name | lower }}/{{ org.services.networkmap.name }}/certs
-    vault delete secret/{{ org.name | lower }}/{{ org.services.networkmap.name }}/tlscerts
-    vault delete secret/{{ org.name | lower }}/{{ org.services.signer.name }}/certs
-    vault delete secret/{{ org.name | lower }}/credentials/keystore
-    vault delete secret/{{ org.name | lower }}/credentials/truststore
-    vault delete secret/{{ org.name | lower }}/credentials/ssl
-    vault delete secret/{{ org.name | lower }}/credentials/cordapps
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/root/certs
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.idman.name }}/certs
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.idman.name }}/crls
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.idman.name }}/tlscerts
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name }}/tlscerts
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/nodekeystore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/sslkeystore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/truststore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name }}/nodeInfo
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name }}/networkparam
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.networkmap.name }}/certs
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.networkmap.name }}/tlscerts
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.signer.name }}/certs
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/keystore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/truststore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/ssl
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/cordapps
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -113,19 +113,19 @@
 # This task deletes crypto material
 - name: Delete Crypto material for nodes
   shell: |
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/customnodekeystore
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/{{ network | json_query('network_services[?type==`idman`].name') | first }}
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/{{ network | json_query('network_services[?type==`networkmap`].name') | first }}
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/networkmaptruststore
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/nodekeystore
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/sslkeystore
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/truststore
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/firewall
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/tlscerts
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/root/certs
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/network-parameters
-    vault delete secret/{{ org.name | lower }}/{{ peer.name | lower }}/credentials
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/customnodekeystore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/{{ network | json_query('network_services[?type==`idman`].name') | first }}
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/{{ network | json_query('network_services[?type==`networkmap`].name') | first }}
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/networkmaptruststore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/nodekeystore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/sslkeystore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/truststore
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/firewall
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/tlscerts
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/root/certs
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/network-parameters
+    vault delete {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/credentials
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -137,7 +137,7 @@
 # This task deletes crypto materials from vault for nodes
 - name: Delete Crypto for nodes
   shell: |
-    vault secrets disable secret/{{ org.name | lower }}
+    vault secrets disable {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/bridge.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/bridge.tpl
@@ -29,7 +29,7 @@ spec:
       role: vault-role
       authpath: cordaent{{ peer.name | lower }}
       serviceaccountname: vault-auth
-      certsecretprefix: secret/{{ peer.name | lower }}/{{ peer.name | lower }}
+      certsecretprefix: {{ vault.secret_path | default('secret') }}/{{ peer.name | lower }}/{{ peer.name | lower }}
       retries: 20
       sleepTimeAfterError: 20
     volume:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/float.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/float.tpl
@@ -29,7 +29,7 @@ spec:
       role: vault-role
       authpath: cordaent{{ peer.name | lower }}
       serviceaccountname: vault-auth
-      certsecretprefix: secret/{{ peer.name | lower }}/{{ peer.name | lower }}
+      certsecretprefix: {{ vault.secret_path | default('secret') }}/{{ peer.name | lower }}/{{ peer.name | lower }}
       retries: 20
       sleepTimeAfterError: 20
     volume:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/idman.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/idman.tpl
@@ -26,7 +26,7 @@ spec:
     acceptLicense: YES
     vault:
       address: {{ org.vault.url }}
-      certSecretPrefix: secret/{{ org.name | lower }}
+      certSecretPrefix: {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}
       role: vault-role
       authPath: cordaent{{ org.name | lower }}
       serviceAccountName: vault-auth

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/nmap.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/nmap.tpl
@@ -29,7 +29,7 @@ spec:
       role: vault-role
       authPath: cordaent{{ org.name | lower }}
       serviceAccountName: vault-auth
-      certSecretPrefix: secret/{{ org.name | lower }}
+      certSecretPrefix: {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}
       retries: 10
       sleepTimeAfterError: 15
     service: 

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node.tpl
@@ -39,7 +39,7 @@ spec:
       role: vault-role
       authpath: cordaent{{ org.name | lower }}
       serviceaccountname: vault-auth
-      certsecretprefix: secret/{{ org.name | lower }}/{{ peer.name | lower }}
+      certsecretprefix: {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}
       nodePath: {{ peer.name | lower }}
       retries: 30
       retryInterval: 30

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
@@ -36,7 +36,7 @@ spec:
       role: vault-role
       authpath: cordaent{{ org.name | lower }}
       serviceaccountname: vault-auth
-      certsecretprefix: secret/{{ org.name | lower }}/{{ peer.name }}
+      certsecretprefix: {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name }}
       nodePath: {{ peer.name | lower }}
       retries: 30
       retryInterval: 30

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
@@ -23,7 +23,7 @@ spec:
       privateCertificate: true
     vault:
       address: {{ org.vault.url }}
-      certSecretPrefix: secret/{{ org.name | lower }}
+      certSecretPrefix: {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}
       serviceAccountName: vault-auth
       role: vault-role
       authPath: cordaent{{ org.name | lower }}

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
@@ -24,7 +24,7 @@ spec:
       privateCertificate: true
     vault:
       address: {{ org.vault.url }}
-      certSecretPrefix: secret/{{ org.name | lower }}
+      certSecretPrefix: {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}
       serviceAccountName: vault-auth
       role: vault-role
       authPath: cordaent{{ org.name | lower }}

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator-node.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator-node.tpl
@@ -28,7 +28,7 @@ spec:
       role: vault-role
       authpath: cordaent{{ peer.name | lower }}
       serviceaccountname: vault-auth
-      certsecretprefix: secret/{{ peer.name | lower }}/{{ peer.name | lower }}
+      certsecretprefix: {{ vault.secret_path | default('secret') }}/{{ peer.name | lower }}/{{ peer.name | lower }}
       retries: 20
       sleepTimeAfterError: 20
     subjects:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator.tpl
@@ -28,7 +28,7 @@ spec:
       role: vault-role
       authpath: cordaent{{ org.name | lower }}
       serviceaccountname: vault-auth
-      certsecretprefix: secret/{{ org.name | lower }}
+      certsecretprefix: {{ vault.secret_path | default('secret') }}/{{ org.name | lower }}
       retries: 20
       sleepTimeAfterError: 20
     cenmServices:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/signer.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/signer.tpl
@@ -26,7 +26,7 @@ spec:
       role: vault-role
       authPath: {{ component_auth }}
       serviceAccountName: vault-auth
-      certSecretPrefix: secret/{{ org.name | lower }}
+      certSecretPrefix: {{ vault.secret_path | default('secret') }}/{{ org.name | lower }}
       retries: 10
       sleepTimeAfterError: 15
     service:

--- a/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
@@ -54,7 +54,7 @@
 # Check if the certs are already created
 - name: Check if the root certs are already created
   shell: |
-    vault kv get -format=yaml secret/{{ org.name | lower }}/root/certs
+    vault kv get -format=yaml {{ vault.secret_path | default('secret') }}/{{ org.name | lower }}/root/certs
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/credentials/tasks/cenm_tasks.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/credentials/tasks/cenm_tasks.yaml
@@ -3,7 +3,7 @@
 # Check if the keystore credentials are already present in the vault
 - name: Check if the keystore credentials are already present in the vault
   shell: |
-    vault read secret/{{ org.name | lower }}/credentials/keystore
+    vault read {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/keystore
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -13,7 +13,7 @@
 # Write the keystore credentials to the vault
 - name: Write the keystore credentials to the vault if they dont exist
   shell: |
-    vault write secret/{{ org.name | lower }}/credentials/keystore idman={{ org.credentials.keystore.idman }} networkmap={{ org.credentials.keystore.networkmap }} subordinateca={{ org.credentials.keystore.subordinateca }} rootca={{ org.credentials.keystore.rootca }} tlscrlsigner={{ org.credentials.keystore.tlscrlsigner }} keyStorePassword={{ org.credentials.keystore.keystore }}
+    vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/keystore idman={{ org.credentials.keystore.idman }} networkmap={{ org.credentials.keystore.networkmap }} subordinateca={{ org.credentials.keystore.subordinateca }} rootca={{ org.credentials.keystore.rootca }} tlscrlsigner={{ org.credentials.keystore.tlscrlsigner }} keyStorePassword={{ org.credentials.keystore.keystore }}
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -22,7 +22,7 @@
 # Check if the truststore credentials are already present in the vault
 - name: Check if the truststore credentials are already present in the vault
   shell: |
-    vault read secret/{{ org.name | lower }}/credentials/truststore
+    vault read {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/truststore
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -32,7 +32,7 @@
 # Write the truststore credentials to the vault
 - name: Write the truststore credentials to the vault if they dont exist
   shell: |
-    vault write secret/{{ org.name | lower }}/credentials/truststore rootca={{ org.credentials.truststore.rootca }} ssl={{ org.credentials.truststore.ssl }} trustStorePassword={{ org.credentials.truststore.truststore }}
+    vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/truststore rootca={{ org.credentials.truststore.rootca }} ssl={{ org.credentials.truststore.ssl }} trustStorePassword={{ org.credentials.truststore.truststore }}
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -41,7 +41,7 @@
 # Check if the ssl credentials are already present in the vault
 - name: Check if the ssl credentials are already present in the vault
   shell: |
-    vault read secret/{{ org.name | lower }}/credentials/ssl
+    vault read {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/ssl
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -51,7 +51,7 @@
 # Write the ssl credentials to the vault
 - name: Write the ssl credentials to the vault if they dont exist
   shell: |
-    vault write secret/{{ org.name | lower }}/credentials/ssl idman={{ org.credentials.ssl.idman }} networkmap={{ org.credentials.ssl.networkmap }} signer={{ org.credentials.ssl.signer }} root={{ org.credentials.ssl.root }}
+    vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/ssl idman={{ org.credentials.ssl.idman }} networkmap={{ org.credentials.ssl.networkmap }} signer={{ org.credentials.ssl.signer }} root={{ org.credentials.ssl.root }}
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -59,7 +59,7 @@
 
 - name: "Write cordapps credentials to vault"
   shell: |
-    vault kv put secret/{{ org.name | lower }}/credentials/cordapps repo_username="{{ org.cordapps.username }}" repo_password="{{ org.cordapps.password }}"
+    vault kv put {{ vault.secret_path | default('secret') }}/{{ org.name | lower }}/credentials/cordapps repo_username="{{ org.cordapps.username }}" repo_password="{{ org.cordapps.password }}"
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/credentials/tasks/node_tasks_nested.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/credentials/tasks/node_tasks_nested.yaml
@@ -1,7 +1,7 @@
 # Check if the node credentials are present in the vault
 - name: Check if the node credentials are already present in the vault
   shell: |
-    vault read secret/{{ org.name | lower }}/{{ peer.name | lower }}/credentials
+    vault read {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/credentials
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -11,7 +11,7 @@
 # Write the networkroot truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
 - name: Write the networkroot truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
   shell: |
-    vault write secret/{{ org.name | lower }}/{{ peer.name | lower }}/credentials root={{ network | json_query('network_services[?type==`networkmap`].truststore_pass') | first }} truststore={{ peer.credentials.truststore }} keystore={{ peer.credentials.keystore }} firewallca={{ peer.credentials.firewallca }} float={{ peer.credentials.float }} bridge={{ peer.credentials.bridge }} {{ peer.name }}={{ peer.name }}P
+    vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/credentials root={{ network | json_query('network_services[?type==`networkmap`].truststore_pass') | first }} truststore={{ peer.credentials.truststore }} keystore={{ peer.credentials.keystore }} firewallca={{ peer.credentials.firewallca }} float={{ peer.credentials.float }} bridge={{ peer.credentials.bridge }} {{ peer.name }}={{ peer.name }}P
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -19,7 +19,7 @@
 
 - name: "Write cordapps credentials to vault"
   shell: |
-    vault write secret/{{ org.name | lower }}/{{ peer.name | lower }}/credentials root={{ network | json_query('network_services[?type==`networkmap`].truststore_pass') | first }} truststore={{ peer.credentials.truststore }} keystore={{ peer.credentials.keystore }} firewallca={{ peer.credentials.firewallca }} float={{ peer.credentials.float }} bridge={{ peer.credentials.bridge }} {{ peer.name }}={{ peer.name }}P repo_username="{{ org.cordapps.username }}" repo_password="{{ org.cordapps.password }}"
+    vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/credentials root={{ network | json_query('network_services[?type==`networkmap`].truststore_pass') | first }} truststore={{ peer.credentials.truststore }} keystore={{ peer.credentials.keystore }} firewallca={{ peer.credentials.firewallca }} float={{ peer.credentials.float }} bridge={{ peer.credentials.bridge }} {{ peer.name }}={{ peer.name }}P repo_username="{{ org.cordapps.username }}" repo_password="{{ org.cordapps.password }}"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
@@ -5,7 +5,7 @@
 # Check if the networkmap certs are already created
 - name: Check if the networkmap certs are already created
   shell: |
-    vault kv get -format=yaml secret/{{ org.name | lower }}/{{ org.services.networkmap.name }}/certs
+    vault kv get -format=yaml {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.networkmap.name }}/certs
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -35,7 +35,7 @@
 # Get the network-root-truststore and save locally
 - name: Get the network-root-truststore
   shell: |
-    vault read -field=network-root-truststore.jks secret/{{ org.name | lower }}/root/certs > "{{ cert_path }}"
+    vault read -field=network-root-truststore.jks {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/root/certs > "{{ cert_path }}"
   vars:
     cert_path: "{{ network | json_query('network_services[?type==`networkmap`].truststore') | first }}"
   environment:
@@ -45,7 +45,7 @@
 # Check if the notary-registration is already completed
 - name: Check if the notary-registration is already completed
   shell: |
-    vault kv get -format=yaml secret/{{ org.name | lower }}/{{ org.services.notary.name | lower }}/certs/truststore
+    vault kv get -format=yaml {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name | lower }}/certs/truststore
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/node_registration/tasks/nested_main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node_registration/tasks/nested_main.yaml
@@ -3,7 +3,7 @@
 # Check if the node-registration is already completed
 - name: Check if the node-registration is already completed
   shell: |
-    vault kv get -format=yaml secret/{{ org.name | lower }}/{{ peer.name | lower }}/certs/truststore
+    vault kv get -format=yaml {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/certs/truststore
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
@@ -39,7 +39,7 @@
 # Check if notary already registered or not
 - name: Check if nodekeystore is already created
   shell: |
-    vault kv get -field=nodekeystore.jks secret/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/nodekeystore
+    vault kv get -field=nodekeystore.jks {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.notary.name }}/certs/nodekeystore
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/signer/tasks/main.yml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/signer/tasks/main.yml
@@ -5,7 +5,7 @@
 # Check if the signer certs are already created
 - name: Check if the signer certs are already created
   shell: |
-    vault kv get -format=yaml secret/{{ org.name | lower }}/{{ org.services.signer.name }}/certs
+    vault kv get -format=yaml {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ org.services.signer.name }}/certs
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/tlscerts/tasks/nested_main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/tlscerts/tasks/nested_main.yaml
@@ -3,7 +3,7 @@
 # Check if the tls certificate is already present in the vault
 - name: Check if the tls certificate is already present in the vault
   shell: |
-    vault read -field={{ service.name }}.crt secret/{{ org.name }}/{{ peer.name }}/certs/{{ service.name }}
+    vault read -field={{ service.name }}.crt {{ org.vault.secret_path | default('secret') }}/{{ org.name }}/{{ peer.name }}/certs/{{ service.name }}
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -13,7 +13,7 @@
 # This task copies the tls certificate to each peer vault
 - name: Copy the tls certificate to each peer vault
   shell: |
-    vault kv put secret/{{ org.name }}/{{ peer.name }}/certs/{{ service.name }} {{ service.name }}.crt="$(cat {{ service.certificate }} | base64 )"
+    vault kv put {{ org.vault.secret_path | default('secret') }}/{{ org.name }}/{{ peer.name }}/certs/{{ service.name }} {{ service.name }}.crt="$(cat {{ service.certificate }} | base64 )"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"
@@ -31,7 +31,7 @@
 # This task copies the networkroottruststore to each org vault
 - name: Copy the networkroottruststore to the Vault for each organisation
   shell: |
-    vault kv put secret/{{ org.name }}/{{ peer.name }}/root/certs network-root-truststore.jks="$(cat {{ service.truststore }})"
+    vault kv put {{ org.vault.secret_path | default('secret') }}/{{ org.name }}/{{ peer.name }}/root/certs network-root-truststore.jks="$(cat {{ service.truststore }})"
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -78,7 +78,7 @@
 - name: Create policy for Access Control for CENM
   shell: |
     cd ./build    
-    echo "path \"secret/{{ org.name | lower }}/*\" {
+    echo "path \"{{ vault.secret_path | default('secret') }}/{{ org.name | lower }}/*\" {
         capabilities = [\"read\", \"list\", \"create\"]
     }"  >>  vault-crypto-{{ org.name | lower }}-ro.hcl
     vault write sys/policy/vault-crypto-{{ org.type }}-{{ org.name | lower }}-ro policy="@vault-crypto-{{ org.name | lower }}-ro.hcl"
@@ -90,7 +90,7 @@
 - name: Create policy for Access Control for nodes
   shell: |
     cd ./build    
-    echo "path \"secret/{{ org.name | lower }}/*\" {
+    echo "path \"{{ vault.secret_path | default('secret') }}/{{ org.name | lower }}/*\" {
         capabilities = [\"read\", \"list\", \"create\"]
     }"  >>  vault-crypto-{{ org.name | lower }}-ro.hcl
     vault write sys/policy/vault-crypto-{{ org.type }}-{{ org.name | lower }}-ro policy="@vault-crypto-{{ org.name | lower }}-ro.hcl"

--- a/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
@@ -73,7 +73,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -188,7 +188,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -292,7 +292,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -393,7 +393,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -497,7 +497,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/r3-corda/configuration/samples/network-cordav2.yaml
+++ b/platforms/r3-corda/configuration/samples/network-cordav2.yaml
@@ -66,7 +66,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -161,7 +161,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -242,7 +242,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -322,7 +322,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -402,7 +402,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:

--- a/platforms/r3-corda/configuration/samples/network-minikube.yaml
+++ b/platforms/r3-corda/configuration/samples/network-minikube.yaml
@@ -63,7 +63,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
@@ -145,7 +145,7 @@ network:
       vault:
         url: "vault_addr"
         root_token: "vault_root_token"
-
+        secret_path: "secret"
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:


### PR DESCRIPTION
**Changelog**
- Add:
network.yaml configurations for vault can now accept an `secret_path` option. 
This option changes the secret engine used for this vault. If not provided it will default to `secret/`
For below example the vault will use the secret engine `supersecret/`
```
# Hashicorp Vault server address and root-token. Vault should be unsealed.
# Do not check-in root_token
vault:
    url: "vault_addr"
    root_token: "vault_root_token"
    secret_path: "supersecret"
```

This initial commit doesn't contain any documentation changes because I am unsure of the scope.
Since this is optional, should I add it to the example network.yaml files but comment it out? 
```
# Hashicorp Vault server address and root-token. Vault should be unsealed.
# Do not check-in root_token
vault:
    url: "vault_addr"
    root_token: "vault_root_token"
    # secret_path: "vault_secret_path"
```
Is there another place it should be refrenced?

**Reviewed by**
@developer_github_id

 

**Linked issue**
#1153 
