### PR TITLE
[Fabric][fix] Install chaincode with lang node

### DIFF
--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -195,6 +195,14 @@ spec:
             CC_SRC_PATH=$CC_SRC_PATH/build/install/${CHAINCODE_NAME}
 
             echo $CC_SRC_PATH
+          elif [ ${CC_RUNTIME_LANGUAGE} = "node" ]
+          then
+            ## Copying desired chaincode to a location relative to $GOPATH/src
+            mkdir -p $GOPATH/src/github.com/chaincode
+            cp -R /tmp/chaincode/{{ $.Values.chaincode.repository.path }}/* $GOPATH/src/github.com/chaincode/
+
+            #chaincode path
+            CC_SRC_PATH="${GOPATH}/src/github.com/chaincode/${CHAINCODE_NAME}/${CHAINCODE_MAINDIR}"
           fi
           version1_4=`echo $NETWORK_VERSION | grep -c 1.4`
           if [ $version1_4 = 1 ];then

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
@@ -253,7 +253,7 @@ network:
             name: "chaincode_name" #This has to be replaced with the name of the chaincode
             version: "chaincode_version" #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"  #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -338,7 +338,7 @@ network:
             name: "chaincode_name"   #This has to be replaced with the name of the chaincode
             version: "chaincode_version"   #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"    #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -428,7 +428,7 @@ network:
             name: "chaincode_name" #This has to be replaced with the name of the chaincode
             version: "chaincode_version" #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"  #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -513,7 +513,7 @@ network:
             name: "chaincode_name"     #This has to be replaced with the name of the chaincode
             version: "chaincode_version"     #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"   #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
@@ -279,7 +279,7 @@ network:
             name: "chaincode_name" #This has to be replaced with the name of the chaincode
             version: "chaincode_version" #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"  #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -365,7 +365,7 @@ network:
             name: "chaincode_name"   #This has to be replaced with the name of the chaincode
             version: "chaincode_version"   #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"    #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -456,7 +456,7 @@ network:
             name: "chaincode_name" #This has to be replaced with the name of the chaincode
             version: "chaincode_version" #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"  #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -542,7 +542,7 @@ network:
             name: "chaincode_name"     #This has to be replaced with the name of the chaincode
             version: "chaincode_version"     #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"   #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -253,7 +253,7 @@ network:
             name: "chaincode_name" #This has to be replaced with the name of the chaincode
             version: "chaincode_version" #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"  #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -338,7 +338,7 @@ network:
             name: "chaincode_name"   #This has to be replaced with the name of the chaincode
             version: "chaincode_version"   #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"    #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -426,7 +426,7 @@ network:
             name: "chaincode_name" #This has to be replaced with the name of the chaincode
             version: "chaincode_version" #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"  #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"
@@ -511,7 +511,7 @@ network:
             name: "chaincode_name"     #This has to be replaced with the name of the chaincode
             version: "chaincode_version"     #This has to be replaced with the version of the chaincode
             maindirectory: "chaincode_main"   #The main directory where chaincode is needed to be placed
-            lang: "golang"  # The language in which the chaincode is written ( golang/ java)
+            lang: "golang"  # The language in which the chaincode is written ( golang/java/node )
             repository:
               username: "git_username"          # Git Service user who has rights to check-in in all branches
               password: "git_access_token"


### PR DESCRIPTION
Signed-off-by: NthMetal <832529@gmail.com>

**Changelog**
- Fix
platforms\hyperledger-fabric\charts\install_chaincode\templates\install_chaincode.yaml
CC_SRC_PATH is not resolved when lang: "node". This causes install to fail when using node chaincode.
Updated yaml to move chaincode and resolve CC_SRC_PATH

**Reviewed by**
@developer_github_id
