### PR TITLE
[Fabric][Fix] Append the channel name to the HelmRelease

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/create_channel_job.tpl
@@ -1,12 +1,12 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: channel-{{ org.name | lower }}
+  name: channel-{{ org.name | lower }}-{{ component_name }}
   namespace: {{ component_ns }}
   annotations:
     fluxcd.io/automated: "false"
 spec:
-  releaseName: channel-{{ org.name | lower }}
+  releaseName: channel-{{ org.name | lower }}-{{ component_name }}
   chart:
     git: {{ git_url }}
     ref: {{ git_branch }}


### PR DESCRIPTION
**Changelog**
- Fix
Flux ignores the new files pushed to the Github for a new
channel creation. Appending the channel name along with
the organization name will make it a unique channel name for
a peer node/organization.


 

**Reviewed by**
@developer_github_id

 

**Linked issue**
#1158
