### PR TITLE
[ Fabric ] Add peer couchdb volume in case of DR

### DIFF
--- a/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/templates/deployment.yaml
@@ -34,27 +34,6 @@ spec:
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
-      volumes:
-      {{ if .Values.vault.tls  }}
-      - name: vaultca
-        secret:
-          secretName: {{ $.Values.vault.tls }}
-          items:
-          - key: ca.crt.pem
-            path: ca-certificates.crt
-      {{ end }}
-      - name: certificates
-        emptyDir:
-          medium: Memory
-      - name: dockersocket
-        hostPath:
-          path: /var/run/docker.sock
-      - name: {{ $.Values.peer.name }}-msp-config-volume
-        configMap:
-          name: {{ $.Values.peer.name }}-msp-config
-          items:
-            - key: mspconfig
-              path: mspconfig
       initContainers:
       - name: certificates-init
         image: {{ $.Values.metadata.images.alpineutils}}
@@ -220,20 +199,30 @@ spec:
         - name: {{ $.Values.peer.name }}-msp-config-volume
           mountPath: /etc/hyperledger/fabric/NodeOUconfig
           readOnly: true
-  volumeClaimTemplates: 
-  - metadata:
-      name: datadir
-    spec:
-      storageClassName: {{ $.Values.storage.peer.storageclassname }}
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: {{ $.Values.storage.peer.storagesize }}
-  - metadata:
-      name: datadir-couchdb     
-    spec:
-      storageClassName: {{ $.Values.storage.couchdb.storageclassname }}    
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: {{ $.Values.storage.couchdb.storagesize }}
+      volumes:
+      {{ if .Values.vault.tls  }}
+      - name: vaultca
+        secret:
+          secretName: {{ $.Values.vault.tls }}
+          items:
+          - key: ca.crt.pem
+            path: ca-certificates.crt
+      {{ end }}
+      - name: certificates
+        emptyDir:
+          medium: Memory
+      - name: dockersocket
+        hostPath:
+          path: /var/run/docker.sock
+      - name: {{ $.Values.peer.name }}-msp-config-volume
+        configMap:
+          name: {{ $.Values.peer.name }}-msp-config
+          items:
+            - key: mspconfig
+              path: mspconfig
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: {{ $.Values.peer.name }}-peer-volume     
+      - name: datadir-couchdb
+        persistentVolumeClaim:
+          claimName: {{ $.Values.peer.name }}-db-volume

--- a/platforms/hyperledger-fabric/charts/peernode/templates/pvc.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/templates/pvc.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.peer.name }}-db-volume
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.peer.name }}-db-volume
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}    
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storage.couchdb.storageclassname }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.couchdb.storagesize }}
+---
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.peer.name }}-peer-volume
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.peer.name }}-db-volume
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}    
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storage.peer.storageclassname }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.peer.storagesize }}


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Update peer CouchDB to use a volume instead of in-memory for its files

**To be reviewed by**
@jagpreetsinghsasan @lakshyakumar 

**Linked issue**
#1132 - see issue for more info on approach for this story, major reworks were deemed out of scope and bug(s) were created