### PR TITLE
[Shared] Add custom IPs to inbound ambassador rules

### DIFF
--- a/docs/source/operations/besu_networkyaml.md
+++ b/docs/source/operations/besu_networkyaml.md
@@ -41,7 +41,8 @@ The snapshot of the `env` section with example value is below
     ## Any additional Ambassador ports can be given below, must be comma-separated without spaces, this is valid only if proxy='ambassador'
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
-    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043  
+    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'  
     retry_count: 50                # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```

--- a/docs/source/operations/corda_networkyaml.md
+++ b/docs/source/operations/corda_networkyaml.md
@@ -42,6 +42,7 @@ The snapshot of the `env` section with example values is below
     type: "env-type"                # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```

--- a/docs/source/operations/fabric_networkyaml.md
+++ b/docs/source/operations/fabric_networkyaml.md
@@ -44,6 +44,7 @@ The snapshot of the `env` section with example value is below
     type: "env_type"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'none' (for minikube)
     ambassadorPorts: 15010,15020    # is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 100                # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```

--- a/docs/source/operations/indy_networkyaml.md
+++ b/docs/source/operations/indy_networkyaml.md
@@ -42,6 +42,7 @@ The snapshot of the `env` section with example values is below
     # Any additional Ambassador ports can be given below, must be comma-separated without spaces. 
     # Must be different from all steward ambassador ports specified in the rest of this network yaml
     ambassadorPorts: 15010,15020,15030,15040 
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: disabled           # Should be enabled if using external-dns for automatic route configuration
 ```

--- a/docs/source/operations/quorum_networkyaml.md
+++ b/docs/source/operations/quorum_networkyaml.md
@@ -45,7 +45,8 @@ The snapshot of the `env` section with example value is below
     ## Any additional Ambassador ports can be given below, must be comma-separated without spaces, this is valid only if proxy='ambassador'
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
-    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043  
+    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'  
     retry_count: 50                # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```

--- a/platforms/hyperledger-besu/configuration/samples/network-besu-newnode.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu-newnode.yaml
@@ -15,6 +15,7 @@ network:
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 3 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15014,15015,15016,15017,15020,15021,15022,15030,15031,15032,15040,15041,15042,15050,15051,15052
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'  
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
@@ -15,6 +15,7 @@ network:
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 3 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15014,15015,15016,15017,15020,15021,15022,15030,15031,15032,15040,15041,15042,15050,15051,15052
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador' 
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
@@ -13,6 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv-add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv-add-peer.yaml
@@ -13,6 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
@@ -13,6 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
@@ -13,6 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -13,6 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-indy/configuration/samples/network-indyv3-aries.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-indyv3-aries.yaml
@@ -15,6 +15,7 @@ network:
     # Any additional Ambassador ports can be given below, must be comma-separated without spaces. 
     # Must be different from all stward ambassador ports specified in the rest of this network yaml
     ambassadorPorts: 15010,15023,15024,15033,15034,15043,15044
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled          # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-indy/configuration/samples/network-indyv3.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-indyv3.yaml
@@ -18,6 +18,7 @@ network:
     # Any additional Ambassador ports can be given below, must be comma-separated without spaces. 
     # Must be different from all other ports specified in the rest of this network yaml
     ambassadorPorts: 15010,15023,15024,15033,15034,15043,15044
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador' 
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/quorum/configuration/samples/network-quorum-newnode.yaml
+++ b/platforms/quorum/configuration/samples/network-quorum-newnode.yaml
@@ -14,7 +14,8 @@ network:
     ## Any additional Ambassador ports can be given below, must be comma-separated without spaces, this is valid only if proxy='ambassador'
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
-    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043  
+    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'   
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/quorum/configuration/samples/network-quorum.yaml
+++ b/platforms/quorum/configuration/samples/network-quorum.yaml
@@ -14,7 +14,8 @@ network:
     ## Any additional Ambassador ports can be given below, must be comma-separated without spaces, this is valid only if proxy='ambassador'
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
-    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043  
+    ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'   
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
@@ -14,6 +14,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
     ambassadorPorts: 15010,15020,15011,15021    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/r3-corda/configuration/samples/network-cordav2.yaml
+++ b/platforms/r3-corda/configuration/samples/network-cordav2.yaml
@@ -14,6 +14,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador' 
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/shared/charts/ambassador/templates/service.yaml
+++ b/platforms/shared/charts/ambassador/templates/service.yaml
@@ -51,6 +51,9 @@ metadata:
   {{- end }}
 spec:
   type: LoadBalancer
+{{- if .Values.ambassador.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.ambassador.loadBalancerSourceRanges }}
+{{- end }} 
   externalTrafficPolicy: Local
   ports:
    - port: {{ .Values.ambassador.port }}

--- a/platforms/shared/charts/ambassador/values.yaml
+++ b/platforms/shared/charts/ambassador/values.yaml
@@ -4,6 +4,7 @@ ambassador:
   port: "8443"
   image: quay.io/datawire/ambassador
   tag: "1.3.2"
+  loadBalancerSourceRanges:
   otherPorts:
     - 10020
     - 10010

--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -49,7 +49,7 @@
     - notest
 - name: Install Ambassador with EIP for Indy
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ terminal.stdout }},{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ terminal.stdout }},{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }}
   tags:
     - ambassador
     - molecule-idempotence-notest
@@ -59,7 +59,7 @@
 
 - name: Install Ambassador with EIP for Besu
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }} 
   tags:
     - ambassador
     - molecule-idempotence-notest
@@ -69,7 +69,7 @@
 
 - name: Install Ambassador for Corda/Quorum
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }}
   tags:
     - ambassador
     - molecule-idempotence-notest
@@ -77,7 +77,7 @@
 
 - name: Install Ambassador for Fabric
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.grpc=enabled --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.grpc=enabled --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }}
   tags:
     - ambassador
     - molecule-idempotence-notest


### PR DESCRIPTION
Signed-off-by: jwavoetacn <68590662+jwavoetacn@users.noreply.github.com>

**Changelog**
- Added the following lines to the ./ambassador/templates/service.yaml:
  - 53: `type: LoadBalancer`
  - 54: `{{- if .Values.ambassador.loadBalancerSourceRanges }}`
  - 55: `loadBalancerSourceRanges: {{ .Values.ambassador.loadBalancerSourceRanges }}`
  - 56: `{{- end }} `
- Added the 'loadBalancerSourceRanges' value to ./ambassador/values.yaml.
- Added '--set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges }}' to 'KUBECONFIG=' in the ./ambassador/tasks/main.yaml.
- Added 'loadBalancerSourceRanges:' to the network-cordav2.yaml.


These changes make it possible to add custom IPs to the inbound rules for the ports in the range: 30000-32767

**To be reviewed by**
@sauveergoel @suvajit-sarkar 

**Linked issue**
resolves #1151 
