### PR TITLE
[ Fabric ]: Fix for chaincode install job

### DIFF
--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -157,7 +157,7 @@ spec:
           mkdir -p $GOPATH/bin && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
           cd $GOPATH/src/github.com/chaincode && dep ensure
           ## Installing chaincode on a peer
-          peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p github.com/chaincode/${CHAINCODE_NAME}/${CHAINCODE_MAINDIR}
+          peer chaincode install -n ${CHAINCODE_NAME} -v ${CHAINCODE_VERSION} -p $GOPATH/src/github.com/chaincode
         env:
         - name: CORE_VM_ENDPOINT
           value: unix:///host/var/run/docker.sock

--- a/platforms/hyperledger-fabric/configuration/roles/create/chaincode/install/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/chaincode/install/tasks/valuefile.yaml
@@ -45,7 +45,7 @@
     type: "install_chaincode_job"
     peer_name: "{{ peer.name }}"
     peer_address: "{{ peer.name }}.{{ namespace }}:{{ peer.grpc.port }}"
-    component_name: "chaincode-install-{{ name }}-{{ peer.name }}-{{ peer.chaincode.version | replace('.','-')}}"
+    component_name: "chaincode-install-{{ name | lower }}-{{ peer.name }}-{{peer.chaincode.name}}{{peer.chaincode.version}}"
     component_chaincode: "{{ peer.chaincode }}"
     fabrictools_image: "hyperledger/fabric-tools:{{ network.version }}"
     alpine_image: "{{ docker_url }}/alpine-utils:1.0"


### PR DESCRIPTION

**Changelog**
- Fix

Description: On line number 158 we are doing change directory to "$GOPATH/src/github.com/chaincode" but on the next command (line no: 160) we were expecting the current directory to be relative to "github.com/chaincode/${CHAINCODE_NAME}/${CHAINCODE_MAINDIR}" path to install the chaincode which is not reachable from the present directory as we already moved at $GOPATH/src/github.com/chaincode/ and the install command is not able to find the chaincode to install
 

**Reviewed by**
@jagpreetsinghsasan 

 

**Linked issue**
#1166 
