### PR TITLE
[ R3-Corda-Ent ] Use enterprise corda node image in notary with validating as true

### DIFF
--- a/platforms/r3-corda-ent/charts/node/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/node/templates/deployment.yaml
@@ -354,7 +354,7 @@ spec:
           else
               echo "Missing node jar file in {{ .Values.nodeConf.jarPath }} folder:"
               ls -al {{ .Values.nodeConf.jarPath }}
-              EXIT_CODE=110
+              EXIT_CODE=1
           fi
 
           if [ "${EXIT_CODE}" -ne "0" ]

--- a/platforms/r3-corda-ent/charts/notary-initial-registration/templates/job.yaml
+++ b/platforms/r3-corda-ent/charts/notary-initial-registration/templates/job.yaml
@@ -51,7 +51,6 @@ spec:
                       exit 1
                   fi
                 }
-
                 # setting up env to get secrets from vault
                 echo "Getting secrets from Vault Server"
                 KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
@@ -59,10 +58,8 @@ spec:
                 validateVaultResponse 'vault login token' "${VAULT_TOKEN}"
                 
                 echo "logged into vault"
-
                 # Creating dirs for storing the certificate
                 mkdir -p ${MOUNT_PATH}/trust-stores
-
                 # Fetching network-root-truststore certificates from vault
                 COUNTER=1
                 while [ "$COUNTER" -lt {{ $.Values.vault.retries }} ]
@@ -80,7 +77,6 @@ spec:
                     fi 
                     COUNTER=`expr "$COUNTER" + 1`
                 done
-
                 if [ "$COUNTER" -ge {{ $.Values.vault.retries }} ]
                 then
                   # printing number of trial done before giving up
@@ -94,12 +90,10 @@ spec:
                 validateVaultResponse "secret (${CERTS_SECRET_PREFIX}/{{ .Values.networkServices.idmanName }}/tlscerts)" "${LOOKUP_SECRET_RESPONSE}"
                 IDMAN_CERT=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tlscacerts"]')
                 echo "${IDMAN_CERT}" | base64 -d > ${MOUNT_PATH}/tlscerts/idman.crt
-
                 LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ .Values.networkServices.networkmapName }}/tlscerts | jq -r 'if .errors then . else . end')
                 validateVaultResponse "secret (${CERTS_SECRET_PREFIX}/{{ .Values.networkServices.networkmapName }}/tlscerts)" "${LOOKUP_SECRET_RESPONSE}"
                 NETWORKMAP_CERT=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tlscacerts"]')
                 echo "${NETWORKMAP_CERT}" | base64 -d > ${MOUNT_PATH}/tlscerts/networkmap.crt
-
                 #Fetching truststore credentials from vault
                 mkdir -p ${MOUNT_PATH}/truststore
                 OUTPUT_PATH=${MOUNT_PATH}/truststore;
@@ -109,7 +103,6 @@ spec:
                 echo "${ROOTCA_TRUSTSTORE}"> ${OUTPUT_PATH}/rootcats
                 TRUSTSTORE_PASSWORD=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["trustStorePassword"]')
                 echo "${TRUSTSTORE_PASSWORD}"> ${OUTPUT_PATH}/ts
-
                 #Fetching keystore credentials from vault
                 mkdir -p ${MOUNT_PATH}/keystore
                 OUTPUT_PATH=${MOUNT_PATH}/keystore;
@@ -136,7 +129,6 @@ spec:
             do
               DB_NODE={{ .Values.dataSourceProperties.dbUrl }}:{{ .Values.dataSourceProperties.dbPort }}
               STATUS=$(nc -vz $DB_NODE 2>&1 | grep -c open )
-
               if [ "$STATUS" == 0 ]
               then
                   FLAG=false
@@ -156,7 +148,6 @@ spec:
                   break
               fi
             done
-
             if [ "$COUNTER" -gt {{ $.Values.healthcheck.readinessthreshold }} ] || [ "$FLAG" == false ]
             then
                 echo "Retry attempted $COUNTER times, no DB up and running. Giving up!"
@@ -190,7 +181,6 @@ spec:
             notary {
                 validating = "{{ .Values.nodeConf.notary.validating }}"
             }
-
             devMode = {{ .Values.nodeConf.devMode }}
             emailAddress : "{{ .Values.nodeConf.email }}"
             myLegalName : "{{ .Values.nodeConf.legalName }}"
@@ -205,7 +195,6 @@ spec:
                 standAloneBroker="{{ .Values.service.rpc.standAloneBroker }}"
                 useSsl="{{ .Values.service.rpc.useSSL }}"
             }
-
             rpcUsers=[
                 {
                     username="{{ .Values.service.rpc.users.username }}"
@@ -215,15 +204,13 @@ spec:
                     ]
                 }
             ]' >> etc/notary.conf
-
             export TRUSTSTORE_PASSWORD=$(cat {{ $.Values.nodeConf.volume.baseDir }}/DATA/truststore/ts)
             sed -i -e "s*TRUSTSTORE_PASSWORD*${TRUSTSTORE_PASSWORD}*g" etc/notary.conf
             export KEYSTORE_PASSWORD=$(cat {{ $.Values.nodeConf.volume.baseDir }}/DATA/keystore/ks)
             sed -i -e "s*KEYSTORE_PASSWORD*${KEYSTORE_PASSWORD}*g" etc/notary.conf
-
             rm -r ${BASE_DIR}/certificates/done.txt
-            yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts
-            yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts
+            yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/zulu8.33.0.1-jdk8.0.192-linux_musl_x64/jre/lib/security/cacerts
+            yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/zulu8.33.0.1-jdk8.0.192-linux_musl_x64/jre/lib/security/cacerts
             
             
             
@@ -255,7 +242,6 @@ spec:
                     break
                 fi
             done
-
             if [ "${EXIT_CODE}" -ne "0" ]
             then
                 HOW_LONG={{ .Values.sleepTimeAfterError }}
@@ -279,7 +265,7 @@ spec:
             # Get the nodeInfo file name and store it in a variable
             nodeInfoFile=$(basename $(ls additional-node-infos/nodeInfo*))
             export nodeInfoFile
-            envsubst <<"EOF" > additional-node-infos/network-parameters-initial.conf.tmp
+            cat <<EOF > additional-node-infos/network-parameters-initial.conf.tmp
             notaries : [
               {
                 notaryNodeInfoFile: "notary-nodeinfo/${nodeInfoFile}"
@@ -291,10 +277,8 @@ spec:
             maxTransactionSize = 10485760
             eventHorizonDays = 1
             EOF
-
             mv additional-node-infos/network-parameters-initial.conf.tmp additional-node-infos/network-parameters-initial.conf
             echo "Created the network-parameters-initial.conf file"
-
             touch ${BASE_DIR}/certificates/done.txt
           volumeMounts:
           - name: notary-etc
@@ -336,7 +320,6 @@ spec:
                  exit 1
               fi
             }           
-
             # perform check if certificates are ready or not, and upload certificate into vault when ready
             COUNTER=1
             cd ${BASE_DIR}/certificates

--- a/platforms/r3-corda-ent/charts/notary/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/notary/templates/deployment.yaml
@@ -217,7 +217,8 @@ spec:
         - |-
           # crearting cordapps dir in volume to keep jars
           {{- if .Values.cordapps.getcordapps }}
-            mkdir -p ${BASE_DIR}/cordapps
+          # Created cordapps directory using permission 'm755' to provide access to user
+            mkdir -p -m775 ${BASE_DIR}/cordapps
             mkdir -p /tmp/downloaded-jars
             # setting up env to get secrets from vault
             KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
@@ -306,10 +307,10 @@ spec:
           rm -rf ${BASE_DIR}/network-parameters
 
           # add idman and networkmap certificates to java keystore
-          yes | keytool -importcert -file ${BASE_DIR}/certificates/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts
-          yes | keytool -importcert -file ${BASE_DIR}/certificates/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts          
+          yes | keytool -importcert -file ${BASE_DIR}/certificates/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/zulu8.33.0.1-jdk8.0.192-linux_musl_x64/jre/lib/security/cacerts
+          yes | keytool -importcert -file ${BASE_DIR}/certificates/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/zulu8.33.0.1-jdk8.0.192-linux_musl_x64/jre/lib/security/cacerts
 
-          #!/bin/sh
+          /bin/sh
           KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/kspass)
           if [ -f {{ .Values.nodeConf.jarPath }}/corda.jar ]
           then
@@ -322,7 +323,7 @@ spec:
           else
               echo "Missing notary jar file in {{ .Values.nodeConf.jarPath }} folder:"
               ls -al {{ .Values.nodeConf.jarPath }}
-              EXIT_CODE=110
+              EXIT_CODE=1
           fi
 
           if [ "${EXIT_CODE}" -ne "0" ]

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
@@ -83,7 +83,7 @@ spec:
         p2pPort: {{ notary_service.p2p.ambassador | default('10002') }}
         external_url_suffix: {{ org.external_url_suffix }}
         p2pAddress: {{ component_name }}.{{ org.external_url_suffix }}:{{ notary_service.p2p.ambassador | default('10002') }}
-      jarPath: /opt/cenm/bin
+      jarPath: /opt/corda
       configPath: etc
       cordaJar:
         memorySize: 1524

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
@@ -71,7 +71,7 @@ spec:
         p2pPort: {{ notary_service.p2p.ambassador | default('10002') }}
         external_url_suffix: {{ org.external_url_suffix }}
         p2pAddress: {{ component_name }}.{{ org.external_url_suffix }}:{{ notary_service.p2p.ambassador | default('10002') }}
-      jarPath: /opt/cenm/bin
+      jarPath: /opt/corda
       configPath: etc
       cordaJar:
         memorySize: 1524

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
@@ -16,7 +16,7 @@ docker_images:
     pki-1.2: corda/enterprise-pki:1.2-zulu-openjdk8u242
     networkmap-1.2: corda/enterprise-networkmap:1.2-zulu-openjdk8u242
     idman-1.2: corda/enterprise-identitymanager:1.2-zulu-openjdk8u242
-    notary-4.4: corda/enterprise-notary:4.4-zulu-openjdk8u242
+    notary-4.4: corda/enterprise-node:4.4
     firewall-4.4: corda/enterprise-firewall:4.4
     node-4.4: corda/enterprise-node:4.4
   init_container: alpine-utils:1.0


### PR DESCRIPTION
Signed-off-by: srinivasan.sankaran <srinivasan.sankaran@accenture.com>

**Changelog**
- Updated the notary vars with enterprise corda node image
- Changed the Corda jar path in notary_initial_registration.tpl and notary.tpl.
- Updated the JVM version as per enterprise node image in notary_inititial_registration and notary job.
- Used cat to replace env values in a file in notary_inititial_registration  job.
- Updated the permission of Cordapps folder in notary deployment.

 

**Reviewed by**
@suvajit-sarkar

 

**Linked issue**
#1187 
