### PR TITLE
[ Fabric ] Fix invoke chaincode for Fabric version 2.2.x and 1.4.x

### DIFF
--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
@@ -166,13 +166,13 @@ spec:
         args:
         - |-
           #!/bin/bash sh
-          export ARGS='{"Args":'"'["${INSTANTIATION_ARGUMENTS}"]'"'}'
+          export ARGS='{"Args":'"'["${INVOKE_ARGUMENTS}"]'"'}'
           export qARGS="'${ARGS}'"
 
           touch ./invokeChaincode.sh	
           
           version1_4=`echo $NETWORK_VERSION | grep -c 1.4`
-          if [ $version1_4 = 1 ];then
+          if [ $version1_4 = 1 ] || [ $ADD_ORGANIZATION = 'true' ];then
             echo "peer chaincode invoke -o ${ORDERER_URL} --tls ${CORE_PEER_TLS_ENABLED} --cafile ${ORDERER_CA} -C ${CHANNEL_NAME} -n ${CHAINCODE_NAME} -c $qARGS" >> ./invokeChaincode.sh
             chmod 755 ./invokeChaincode.sh
             sh ./invokeChaincode.sh
@@ -244,6 +244,8 @@ spec:
           value: "{{ $.Values.endorsers.name }}"
         - name: NETWORK_VERSION
           value: "{{ $.Values.metadata.network.version }}"
+        - name: ADD_ORGANIZATION
+          value: "{{ $.Values.metadata.add_organization }}"
         volumeMounts:
         - name: certificates
           mountPath: /opt/gopath/src/github.com/hyperledger/fabric/crypto

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/values.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/values.yaml
@@ -12,6 +12,8 @@ metadata:
     #Provide the valid image name and version to read certificates from vault server
     #Eg. alpineutils: gcr.io/acn-stp-on-blockchain/alpine-utils
     alpineutils: 
+  #Flag for ivoking the chaincode for addition of an org or for the first network
+  add_organization:
   #Provide the custom labels
   #NOTE: Provide labels other than name, release name , release service, chart version , chart name , app.
   #Eg. labels:

--- a/platforms/hyperledger-fabric/configuration/roles/create/chaincode/invoke/Readme.md
+++ b/platforms/hyperledger-fabric/configuration/roles/create/chaincode/invoke/Readme.md
@@ -4,8 +4,8 @@ This role creates helm value file for the deployment of chaincode_invoke job
 ### main.yaml
 ### Tasks
 (Variables with * are fetched from the playbook which is calling this role)
-#### 1. Create value file for chaincode invocation
-This task creates value file for chaincode invocation.
+#### 1. Create value file for chaincode invocation with creator organization
+This task creates value file for chaincode invocation with creator organization.
 ##### Input Variables
 
     channelcreator_query:  query based on type, "participants[?type=='creator']"
@@ -16,6 +16,23 @@ This task creates value file for chaincode invocation.
 **loop_control**: Specify conditions for controlling the loop.
                 
     loop_var: loop variable used for iterating the loop.
+
+**when** : It runs when `add_new_org` is not defined or `false`.
+
+#### 2. Create value file for chaincode invocation with new organization
+This task creates value file for chaincode invocation with new organization.
+##### Input Variables
+
+    channelcreator_query:  query based on type, "participants[?org_status=='new']"
+    org_query: query based on name "organizations[?name=='{{participant.name}}']"
+    org: query result of org_query"{{ network | json_query(org_query) | first }}"
+**include_tasks**: It includes the name of intermediatory task which is required for creating the value file, here `valuefile.yaml`.
+**loop**: loops over peers list fetched from *{{ component_peers }}* from network yaml
+**loop_control**: Specify conditions for controlling the loop.
+                
+    loop_var: loop variable used for iterating the loop.
+
+**when** : It runs when `add_new_org` is defined and `true`.
 
 -------
 ### valuefile.yaml

--- a/platforms/hyperledger-fabric/configuration/roles/create/chaincode/invoke/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/chaincode/invoke/tasks/main.yaml
@@ -4,13 +4,28 @@
 #############################################################################################
 
 ############################################################################################
-# Create value file for chaincode invocation
-- name: "Create value file for chaincode invocation"
+# Create value file for chaincode invocation with creator organization
+- name: "Create value file for chaincode invocation with creator organization"
   include_tasks: valuefile.yaml
   vars:
-    channelcreator_query: "participants[?(type=='creator' || (org_status=='new' && add_new_org=='true'))]"
+    channelcreator_query: "participants[?type=='creator']"
     org_query: "organizations[?name=='{{participant.name}}']"
     org: "{{ network | json_query(org_query) | first }}"
+    add_organization: 'false'
   loop: "{{ item | json_query(channelcreator_query) }}"
   loop_control:
     loop_var: participant
+  when: add_new_org is not defined or add_new_org == 'false'
+
+# Create value file for chaincode invocation with new organization
+- name: "Create value file for chaincode invocation with new organization"
+  include_tasks: valuefile.yaml
+  vars:
+    channelcreator_query: "participants[?org_status=='new']"
+    org_query: "organizations[?name=='{{participant.name}}']"
+    org: "{{ network | json_query(org_query) | first }}"
+    add_organization: 'true'
+  loop: "{{ item | json_query(channelcreator_query) }}"
+  loop_control:
+    loop_var: participant
+  when: add_new_org is defined and add_new_org == 'true'

--- a/platforms/hyperledger-fabric/configuration/roles/create/chaincode/invoke/tasks/valuefile.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/chaincode/invoke/tasks/valuefile.yaml
@@ -99,7 +99,9 @@
   loop: "{{ org.services.peers }}"
   loop_control:
     loop_var: peer
-  when: peer.chaincode is defined and invoke_chaincode.results[0].resources|length == 0
+  when: 
+    - peer.chaincode is defined
+    - invoke_chaincode.results[0].resources|length == 0 or add_new_org == 'true'
 
 #Git Push : Pushes the above generated files to git directory 
 - name: Git Push
@@ -114,4 +116,4 @@
     GIT_BRANCH: "{{ org.gitops.branch }}"
     GIT_RESET_PATH: "platforms/hyperledger-fabric/configuration"
     msg: "[ci skip] Pushing chaincode invocation files"
-  when: invoke_chaincode.results[0].resources|length == 0
+  when: invoke_chaincode.results[0].resources|length == 0 or add_new_org == 'true'

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/invoke_chaincode_job.tpl
@@ -16,6 +16,7 @@ spec:
       namespace: {{ namespace }}
       network:
         version: {{ network.version }}
+      add_organization: {{ add_organization }}
       images:
         fabrictools: {{ fabrictools_image }}
         alpineutils: {{ alpine_image }}
@@ -49,4 +50,9 @@ spec:
         creator: {{ namespace }}
         name: {% for name in approvers.name %} {{ name }} {% endfor %} 
         corepeeraddress: {% for address in approvers.corepeerAddress %} {{ address }} {% endfor %}
+{% else %}
+    endorsers:
+        creator: {{ namespace }}
+        name: {{ peer_name }}
+        corepeeraddress: {{ peer_address }}
 {% endif %}


### PR DESCRIPTION
Signed-off-by: lakshyakumar <lakshya.kumar@accenture.com>

**Changelog**
- Add the `add_organization` flag to the `invoke chaincode tpl` file and the `invoke chaincode chart` to invoke with the correct command and condition.
- Fix the arguments passed with the init function in case of fabric version 1.4.x .
- Fix the `chaincode Invoke role` to invoke the chaincode after the addition of new organization in fabric version 1.4.x and 2.2.x .

 

**Reviewed by**
@jagpreetsinghsasan 

 

**Linked issue**
#1206 
