### PR TITLE
[ Fabric ] Update couchdb image for HLF 2.2.0

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/create/peers/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/peers/tasks/main.yaml
@@ -21,7 +21,7 @@
     name: "{{ item.name | lower }}"
     type: "value_peer"
     component_name: values-{{ peer.name }}
-    couchdb_image: "hyperledger/fabric-couchdb:{{ couchdb_image_version[network.version] }}"
+    couchdb_image: "{{ docker_url }}/{{ couchdb_image_version[network.version] }}"
     peer_image: "hyperledger/fabric-peer:{{ network.version }}"
     alpine_image: "{{ docker_url }}/alpine-utils:1.0"
     peer_name: "{{ peer.name }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/peers/vars/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/peers/vars/main.yaml
@@ -1,5 +1,5 @@
 couchdb_image_version:
-  1.4.0: 0.4.14
-  1.4.4: 0.4.18
-  2.0.0: 0.4.18
-  2.2.0: 0.4.18
+  1.4.0: "hyperledger/fabric-couchdb:0.4.14"
+  1.4.4: "hyperledger/fabric-couchdb:0.4.18"
+  2.0.0: "hyperledger/fabric-couchdb:0.4.18"
+  2.2.0: "couchdb:3.1"


### PR DESCRIPTION
Signed-off-by: abevers <arnoud.bevers@accenture.com>

**Changelog**
- Update peer CouchDB image for HLF 2.2.0 from `hyperledger/fabric-couchdb:0.4.18` to `couchdb:3.1`

**To be reviewed by**
@jagpreetsinghsasan @lakshyakumar 

**Linked issue**
Resolves #1088  
