### PR TITLE
[ R3-Corda-Ent ] Changes for using https for flux

### DIFF
--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/bridge.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/bridge.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/bridge
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/db.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/db.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/h2
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/float.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/float.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/float
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/idman.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/idman.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/idman
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/nmap.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/nmap.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/nmap
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/node-initial-registration
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/notary
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/notary-initial-registration
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator-node.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator-node.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/generate-pki-node
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/generate-pki
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/signer.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/signer.tpl
@@ -9,7 +9,7 @@ spec:
   releaseName: {{ org.services.signer.name }}
   chart:
     path: {{ org.gitops.chart_source }}/{{ chart }}
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_https }}
     ref: {{ org.gitops.branch }}
   values:
     nodeName: {{ org.services.signer.name }}

--- a/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
@@ -7,8 +7,9 @@
     item: "{{ org.services.float }}"
     kubeconfig_path: "{{ item.k8s.config_file }}"
     kubecontext: "{{ item.k8s.context }}"
-    git_url: "{{ item.gitops.git_ssh }}"
-    git_key: "{{ item.gitops.private_key }}"
+    git_username: "{{ item.gitops.username }}"
+    git_password: "{{ item.gitops.password }}"
+    git_repo: "{{ item.gitops.git_push_url }}"
     git_branch: "{{ item.gitops.branch }}"
     git_path: "{{ item.gitops.release_dir }}"
     git_host: "{{ item.gitops.git_push_url.split('/')[0] | lower }}" # extract the hostname from the git_push_url

--- a/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
@@ -138,7 +138,7 @@
     name: helm_component
   vars:
     helm_lint: "true"
-    git_url: "{{ org.gitops.git_ssh }}"
+    git_url: "{{ org.gitops.git_https }}"
     git_branch: "{{ org.gitops.branch }}"
     charts_dir: "{{ org.gitops.chart_source }}"
     component_name: "{{ peer.name | lower }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
@@ -57,7 +57,7 @@
     notary_name: "{{ notary_service.name }}"
     values_dir: "{{playbook_dir}}/../../../{{ org.gitops.release_dir }}"
     charts_dir: "{{ org.gitops.chart_source }}"
-    git_url: "{{ org.gitops.git_ssh }}"
+    git_url: "{{ org.gitops.git_https }}"
     git_branch: "{{ org.gitops.branch }}"
     idman_url: "{{ network | json_query('network_services[?type==`idman`].uri') | first }}"
     idman_domain: "{{ idman_url.split(':')[1] | regex_replace('/', '') }}"    

--- a/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
@@ -79,7 +79,7 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -87,7 +87,6 @@ network:
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -202,7 +201,7 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -210,7 +209,6 @@ network:
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -241,7 +239,7 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -249,7 +247,6 @@ network:
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999
@@ -328,7 +325,7 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -336,7 +333,6 @@ network:
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -366,7 +362,7 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -374,7 +370,6 @@ network:
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999
@@ -453,7 +448,7 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -461,7 +456,6 @@ network:
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
 
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -491,7 +485,7 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -499,7 +493,6 @@ network:
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999
@@ -578,7 +571,7 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -586,7 +579,6 @@ network:
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -616,7 +608,7 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_https: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
@@ -624,7 +616,6 @@ network:
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999

--- a/platforms/shared/configuration/kubernetes-env-setup.yaml
+++ b/platforms/shared/configuration/kubernetes-env-setup.yaml
@@ -13,8 +13,9 @@
     vars:
       kubeconfig_path: "{{ item.k8s.config_file }}"
       kubecontext: "{{ item.k8s.context }}"
-      git_url: "{{ item.gitops.git_ssh }}"
-      git_key: "{{ item.gitops.private_key }}"
+      git_username: "{{ item.gitops.username }}"
+      git_password: "{{ item.gitops.password }}"
+      git_repo: "{{ item.gitops.git_push_url }}"
       git_branch: "{{ item.gitops.branch }}"
       git_path: "{{ item.gitops.release_dir }}"
       git_host: "{{ item.gitops.git_push_url.split('/')[0] | lower }}" # extract the hostname from the git_push_url

--- a/platforms/shared/configuration/molecule/kubernetes-corda/cleanup.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/cleanup.yml
@@ -8,11 +8,6 @@
     file:
       path: ../../../platforms
       state: absent
-  - name: Delete the known_hosts file
-    file:
-      path: flux_known_hosts
-      state: absent
-  - name: Delete the temp secret file
     file:
       path: test_rsa.pem
       state: absent

--- a/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
@@ -44,8 +44,9 @@
           k8s:
             config_file: "/tmp/molecule/kind-default/kubeconfig"
             context: "kind"
-        git_url: "ssh://git@github.com/hyperledger-labs/blockchain-automation-framework.git"
-        git_key: "test_rsa.pem"
+        git_username: "hyperledger-labs"
+        git_password: "to-be-configured"
+        git_repo: "github.com/hyperledger-labs/blockchain-automation-framework.git"
         git_branch: "develop"
         git_path: "platforms/r3-corda/releases/test"
         git_host: "github.com"

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/cleanup.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/cleanup.yml
@@ -8,10 +8,6 @@
     file:
       path: ../../../platforms
       state: absent
-  - name: Delete the known_hosts file
-    file:
-      path: flux_known_hosts
-      state: absent
   - name: Delete the temp secret file
     file:
       path: test_rsa.pem

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
@@ -44,8 +44,9 @@
           k8s:
             config_file: "/tmp/molecule/kind-default/kubeconfig"
             context: "kind"
-        git_url: "ssh://git@github.com/hyperledger-labs/blockchain-automation-framework.git"
-        git_key: "test_rsa.pem"
+        git_username: "hyperledger-labs"
+        git_password: "to-be-configured"
+        git_repo: "github.com/hyperledger-labs/blockchain-automation-framework.git"
         git_branch: "develop"
         git_path: "platforms/r3-corda/releases/test"
         git_host: "github.com"

--- a/platforms/shared/configuration/molecule/kubernetes-indy/cleanup.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-indy/cleanup.yml
@@ -8,10 +8,6 @@
     file:
       path: ../../../platforms
       state: absent
-  - name: Delete the known_hosts file
-    file:
-      path: flux_known_hosts
-      state: absent
   - name: Delete the secret file
     file:
       path: test_rsa.pem

--- a/platforms/shared/configuration/molecule/kubernetes-indy/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-indy/converge.yml
@@ -63,8 +63,9 @@
           k8s:
             config_file: "/tmp/molecule/kind-default/kubeconfig"
             context: "kind"
-        git_url: "ssh://git@github.com/hyperledger-labs/blockchain-automation-framework.git"
-        git_key: "test_rsa.pem"
+        git_username: "hyperledger-labs"
+        git_password: "to-be-configured"
+        git_repo: "github.com/hyperledger-labs/blockchain-automation-framework.git"
         git_branch: "develop"
         git_path: "platforms/r3-corda/releases/test"
         git_host: "github.com"

--- a/platforms/shared/configuration/roles/setup/Readme.md
+++ b/platforms/shared/configuration/roles/setup/Readme.md
@@ -75,11 +75,6 @@ This task first creates the HelmRelease Custom resource, and then deploys Flux h
 #### 5. wait for pods to come up
 This checks for the flux Pods to come up. It runs when *flux_service.resources* is not there i.e. flux is not found, until kubectl_get_pods gives a positive result.
 
-#### 6. Get ssh key
-This tasks gets the ssh key. Stores the result in *ssh_key*.
-
-#### 7. Output ssh key
-It outputs the ssh key stored in *ssh_key*.
 
 -------------
 

--- a/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
@@ -14,12 +14,6 @@
   tags:
     - flux
 
-- name: Get ssh known hosts
-  shell: |
-    ssh-keyscan {{ git_host }} > flux_known_hosts
-    chmod -R 777 flux_known_hosts
-  when: flux_service.resources|length == 0
-
 - name: Helm repo add
   shell: |
     helm repo add fluxcd https://charts.fluxcd.io
@@ -29,10 +23,10 @@
 
 - name: Install flux
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl create secret generic git-auth-{{ network.env.type }} --from-file=identity={{ git_key }} --namespace default
+    KUBECONFIG={{ kubeconfig_path }} kubectl create secret generic git-auth-{{ network.env.type }} --from-literal=GIT_AUTHUSER={{ git_username }}  --from-literal=GIT_AUTHKEY={{ git_password }} --namespace default
     KUBECONFIG={{ kubeconfig_path }} kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/{{ helm_operator_version }}/deploy/crds.yaml --context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }} {{ playbook_dir }}/../../../platforms/shared/charts/flux --namespace default --set git.secretName=git-auth-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='{{ git_url }}' --set git.branch={{ git_branch }} --set git.label='sync-{{ network.env.type }}' --set git.path="{{ git_path }}" --set-file ssh.known_hosts=flux_known_hosts --set registry.insecureHosts="{{ network.docker.url }}" --kube-context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }}-helm-operator fluxcd/helm-operator --namespace default --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='{{ git_url }}' --set git.ssh.secretName=git-auth-{{ network.env.type }} --set-file git.ssh.known_hosts=flux_known_hosts --set helm.versions=v3 --kube-context="{{ kubecontext }}"
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }} {{ playbook_dir }}/../../../platforms/shared/charts/flux --namespace default --set git.secretName=git-auth-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='https://{{ git_username }}:{{ git_password }}@{{ git_repo }}' --set git.branch={{ git_branch }} --set git.label='sync-{{ network.env.type }}' --set git.path="{{ git_path }}"  --set registry.insecureHosts="{{ network.docker.url }}" --kube-context="{{ kubecontext }}"
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }}-helm-operator fluxcd/helm-operator --namespace default --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='https://{{ git_username }}:{{ git_password }}@{{ git_repo }}' --set git.ssh.secretName=git-auth-{{ network.env.type }} --set helm.versions=v3 --kube-context="{{ kubecontext }}"
   when: flux_service.resources|length == 0
   tags:
     - flux
@@ -51,14 +45,3 @@
       - app = flux
       - release = flux-{{ network.env.type }}
   when: flux_service.resources|length == 0
-
-- name: Get ssh key
-  shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl -n default logs deployment/flux-{{ network.env.type }} | grep identity.pub | cut -d '"' -f2
-  register: ssh_key
-  changed_when: false
-
-- name: Output ssh key
-  debug:
-    var: ssh_key.stdout
-  changed_when: false


### PR DESCRIPTION
Signed-off-by: srinivasan.sankaran <srinivasan.sankaran@accenture.com>

**Changelog**
 - Updated template,roles,molecule test and network yaml references to https from ssh for r3-corda-ent.
 - Updated the shared/setup readme file to reflect recent flux changes.
 - Updated shared/setup/flux role to use git username,password and url for https.
 - Removed references of ssh from setup/flux/role.
 - Updated the vars of the role from where shared/flux/setup role is called for r3-corda-ent.

 

**Reviewed by**
@suvajit-sarkar 
@jagpreetsinghsasan

 

**Linked issue**
#1220
