### PR TITLE
Added Workflow for molecule test on develop branch PRs

### DIFF
--- a/.github/workflows/molecule_test.yml
+++ b/.github/workflows/molecule_test.yml
@@ -1,0 +1,65 @@
+# This is custom git Action created to run molecule test cases during any push on develop branch
+# The workflow is divided into test stages, based on the PR title particular test stages will run
+# The test coverage is for BAF corda and fabric. Other DLTs will be added gradually
+
+name: Molecule Test Workflow
+
+on:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install molecule==3.0.6 yamllint ansible-lint docker==4.2.2 openshift
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      if: |
+        contains(github.event.pull_request.title, '[shared]') ||
+        contains(github.event.pull_request.title, '[corda]') ||
+        contains(github.event.pull_request.title, '[fabric]')
+    - name: Test Stage Shared default
+      run: |
+        cd ./platforms/shared/configuration
+        molecule test -s default
+      if: contains(github.event.pull_request.title, '[shared]')
+    - name: Test Stage kubernetes-corda
+      run: |
+        cd ./platforms/shared/configuration
+        molecule test -s kubernetes-corda
+      if: contains(github.event.pull_request.title, '[shared]')
+    - name: Test Stage kubernetes-fabric
+      run: |
+        cd ./platforms/shared/configuration
+        molecule test -s kubernetes-fabric
+      if: contains(github.event.pull_request.title, '[shared]')
+    - name: Test Stage Fabric default
+      run: | 
+        cd ./platforms/hyperledger-fabric/configuration
+        molecule test -s default
+      if: contains(github.event.pull_request.title, '[fabric]')
+    - name: Test Stage Fabric default
+      run: | 
+        cd ./platforms/hyperledger-fabric/configuration
+        molecule test -s default
+      if: contains(github.event.pull_request.title, '[fabric]')
+    - name: Test Stage Fabric crypto
+      run: | 
+        cd ./platforms/hyperledger-fabric/configuration
+        molecule test -s crypto
+      if: contains(github.event.pull_request.title, '[fabric]')
+    - name: Test Stage Corda default
+      run: | 
+        cd ./platforms/r3-corda/configuration
+        molecule test -s default
+      if: contains(github.event.pull_request.title, '[corda]')


### PR DESCRIPTION
Signed-off-by: suvajit-sarkar <suvajit.sarkar@accenture.com>

**Changelog**
- Add github workflows for molecule test on develop branch PRs
- The workflow test coverage is for molecule tests only and corda and fabrics DLTs for now
- The tests stages will run only for PRs with title containing the following tags : [shared] or [corda] or [fabric]

 

**Reviewed by**
@sownak 

 

**Linked issue**
#1227 
