### PR TITLE
[ R3-Corda-Ent ] Changes for using HTTPS for flux 

### DIFF
--- a/examples/supplychain-app/quorum/express_nodeJS/controllers/container.js
+++ b/examples/supplychain-app/quorum/express_nodeJS/controllers/container.js
@@ -35,7 +35,6 @@ router.get("/:trackingID?", function(req, res) {
           container.custodian = newContainer.custodian;
           container.custodian = container.custodian + "," + newContainer.lastScannedAt;
           container.trackingID = newContainer.trackingID;
-          console.log(protocol,"*****");
           if(protocol==="raft")
             container.timestamp  = (new Date(newContainer.timestamp/1000000)).getTime();
           else

--- a/platforms/r3-corda-ent/configuration/roles/create/namespace_serviceaccount/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/create/namespace_serviceaccount/README.md
@@ -66,7 +66,7 @@ This task pushes generated Helm releases into remote branch.
 This task calls role from: `{{ playbook_dir }}/../../shared/configuration/roles/git_push`
 #### Input Variables:
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/create/namespace_serviceaccount/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/namespace_serviceaccount/tasks/main.yaml
@@ -58,7 +58,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ gitops.git_push_url }}"
+    GIT_REPO: "{{ gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ gitops.username }}"
     GIT_EMAIL: "{{ gitops.email }}"
     GIT_PASSWORD: "{{ gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/create/storageclass/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/create/storageclass/README.md
@@ -32,7 +32,7 @@ This task creates value file for storageclass by calling `create/k8_component` r
 This task pushes the generated deployment files to the GIT repository by calling `shared/configuration/roles/git_push` role.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/create/storageclass/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/storageclass/tasks/main.yaml
@@ -31,7 +31,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ gitops.git_push_url }}"
+    GIT_REPO: "{{ gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ gitops.username }}"
     GIT_EMAIL: "{{ gitops.email }}"
     GIT_PASSWORD: "{{ gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/delete/gitops_files/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/delete/gitops_files/README.md
@@ -18,7 +18,7 @@ This task deletes all the files from the release directory
 This task pushes the current state to the GIT repo after deleting value files from `release_dir` by calling the `shared/configuration/roles/git_push` role.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/delete/gitops_files/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/delete/gitops_files/tasks/main.yaml
@@ -15,7 +15,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ gitops.git_push_url }}"
+    GIT_REPO: "{{ gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ gitops.username }}"
     GIT_EMAIL: "{{ gitops.email }}"
     GIT_PASSWORD: "{{ gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/bridge.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/bridge.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/bridge
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/db.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/db.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/h2
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/float.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/float.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/float
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/idman.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/idman.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/idman
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/nmap.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/nmap.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/nmap
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/node_registration.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/node-initial-registration
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/notary
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/notary_initial_registration.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/notary-initial-registration
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator-node.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator-node.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/generate-pki-node
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/pki-generator.tpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: {{ component_name }}
   chart:
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
     path: {{ charts_dir }}/generate-pki
   values:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/signer.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/signer.tpl
@@ -9,7 +9,7 @@ spec:
   releaseName: {{ org.services.signer.name }}
   chart:
     path: {{ org.gitops.chart_source }}/{{ chart }}
-    git: {{ org.gitops.git_ssh }}
+    git: {{ org.gitops.git_url }}
     ref: {{ org.gitops.branch }}
   values:
     nodeName: {{ org.services.signer.name }}

--- a/platforms/r3-corda-ent/configuration/roles/setup/bridge/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/bridge/README.md
@@ -43,7 +43,7 @@ This tasks creates deployment file for bridge node by calling the `helm_componen
 This tasks push the created value files into repository by calling the `shared/configuration/roles/git_push` role.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/bridge/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/bridge/tasks/main.yaml
@@ -30,7 +30,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/float-environment/tasks/main.yaml
@@ -7,11 +7,13 @@
     item: "{{ org.services.float }}"
     kubeconfig_path: "{{ item.k8s.config_file }}"
     kubecontext: "{{ item.k8s.context }}"
-    git_url: "{{ item.gitops.git_ssh }}"
-    git_key: "{{ item.gitops.private_key }}"
+    git_username: "{{ item.gitops.username }}"
+    git_password: "{{ item.gitops.password }}"
+    git_repo: "{{ item.gitops.git_url.split('//')[1] | lower }}"
     git_branch: "{{ item.gitops.branch }}"
     git_path: "{{ item.gitops.release_dir }}"
-    git_host: "{{ item.gitops.git_push_url.split('/')[0] | lower }}" # extract the hostname from the git_push_url
+    git_host: "{{ item.gitops.git_url.split('/')[2] | lower }}" # extract the hostname from the git_url
+    ssh: "{{ item.gitops.ssh | default(false) }}"
     helm_operator_version: "1.2.0"
 
 - name: Setup ambassador for float cluster

--- a/platforms/r3-corda-ent/configuration/roles/setup/float/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/float/README.md
@@ -41,7 +41,7 @@ This tasks creates deployment file for the Float component of the Node firewall 
 This tasks push the created value files into repository by calling git_push role from shared.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/float/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/float/tasks/main.yaml
@@ -18,7 +18,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ gitops.git_push_url }}"
+    GIT_REPO: "{{ gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ gitops.username }}"
     GIT_EMAIL: "{{ gitops.email }}"
     GIT_PASSWORD: "{{ gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/idman/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/idman/README.md
@@ -44,7 +44,7 @@ This task creates deployment file for the Idman component the CENM by calling th
 This task pushes the created value files into repository by calling the `git_push` role from shared.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/idman/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/idman/tasks/main.yaml
@@ -40,7 +40,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/nmap/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/nmap/README.md
@@ -99,7 +99,7 @@ This tasks creates deployment file for nmap node by calling the `helm_component`
 This task pushes the created value files into repository by calling the `git_push` role from shared.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
@@ -91,7 +91,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/node/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node/README.md
@@ -144,7 +144,7 @@ This task will create the value file for the node by calling the `helm_component
 ----
 #### 16. Push the created deployment files to repository
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
@@ -138,7 +138,7 @@
     name: helm_component
   vars:
     helm_lint: "true"
-    git_url: "{{ org.gitops.git_ssh }}"
+    git_url: "{{ org.gitops.git_url }}"
     git_branch: "{{ org.gitops.branch }}"
     charts_dir: "{{ org.gitops.chart_source }}"
     component_name: "{{ peer.name | lower }}"
@@ -159,7 +159,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/node_registration/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node_registration/README.md
@@ -60,7 +60,7 @@ This task creates deployment file for node registration by calling the `helm_com
 This task pushes the created value files into repository by calling the `git_push` role from shared.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/node_registration/tasks/nested_main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node_registration/tasks/nested_main.yaml
@@ -51,7 +51,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/README.md
@@ -79,7 +79,7 @@ This task creates deployment files for job for notary by calling the `helm_compo
 This task pushes the created value files into repository by calling git_push role from shared.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary-initial-registration/tasks/main.yaml
@@ -57,7 +57,7 @@
     notary_name: "{{ notary_service.name }}"
     values_dir: "{{playbook_dir}}/../../../{{ org.gitops.release_dir }}"
     charts_dir: "{{ org.gitops.chart_source }}"
-    git_url: "{{ org.gitops.git_ssh }}"
+    git_url: "{{ org.gitops.git_url }}"
     git_branch: "{{ org.gitops.branch }}"
     idman_url: "{{ network | json_query('network_services[?type==`idman`].uri') | first }}"
     idman_domain: "{{ idman_url.split(':')[1] | regex_replace('/', '') }}"    
@@ -71,7 +71,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary/README.md
@@ -52,7 +52,7 @@ This tasks creates deployment files for the notary by calling the `helm_componen
 This tasks pushes the created value files into repository by calling the shared `git_push` role.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/main.yaml
@@ -46,7 +46,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/pki-generator-node/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/pki-generator-node/README.md
@@ -38,7 +38,7 @@ This task will create the deployment files for the generate-pki-node job by call
 This tasks push the created value files into repository by calling git_push role from shared.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/pki-generator-node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/pki-generator-node/tasks/main.yaml
@@ -31,7 +31,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ gitops.git_push_url }}"
+    GIT_REPO: "{{ gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ gitops.username }}"
     GIT_EMAIL: "{{ gitops.email }}"
     GIT_PASSWORD: "{{ gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/pki-generator/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/pki-generator/README.md
@@ -43,7 +43,7 @@ This task will create the deployment files for the generate-pki job by calling t
 This tasks push the created value files into repository by calling git_push role from shared.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/pki-generator/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/pki-generator/tasks/main.yaml
@@ -38,7 +38,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ gitops.git_push_url }}"
+    GIT_REPO: "{{ gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ gitops.username }}"
     GIT_EMAIL: "{{ gitops.email }}"
     GIT_PASSWORD: "{{ gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/roles/setup/signer/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/signer/README.md
@@ -49,7 +49,7 @@ This task creates deployment file for signer node by calling the `helm_component
 This tasks pushes the created value files into repository by calling the shared `git_push` role.
 ##### Input Variables
 - `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
-- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_push_url }}` from `network.yaml`
+- *`GIT_REPO` - HTTPS URL for GIT repository, used for pushing deployment files; uses the variable `{{ gitops.git_url }}` from `network.yaml`
 - *`GIT_USERNAME`: Username with access to the GIT repository; uses `{{ gitops.username }}` from `network.yaml`
 - *`GIT_EMAIL`: Email associated with the username above; uses `{{ gitops.email }}` from `network.yaml`
 - *`GIT_PASSWORD`: Password (most of the time access token) with write access to the GIT repository; uses `{{ gitops.password }}` from `network.yaml`

--- a/platforms/r3-corda-ent/configuration/roles/setup/signer/tasks/main.yml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/signer/tasks/main.yml
@@ -44,7 +44,7 @@
     name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
   vars:
     GIT_DIR: "{{ playbook_dir }}/../../../"
-    GIT_REPO: "{{ org.gitops.git_push_url }}"
+    GIT_REPO: "{{ org.gitops.git_url.split('//')[1] | lower }}"
     GIT_USERNAME: "{{ org.gitops.username }}"
     GIT_EMAIL: "{{ org.gitops.email }}"
     GIT_PASSWORD: "{{ org.gitops.password }}"

--- a/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
@@ -79,15 +79,14 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+        ssh: false
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-        git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -202,15 +201,14 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+        ssh: false
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-        git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -241,15 +239,14 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+            ssh: false
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-            git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999
@@ -328,15 +325,14 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+        ssh: false
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-        git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -366,15 +362,14 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+            ssh: false
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-            git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999
@@ -453,15 +448,14 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+        ssh: false
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-        git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
 
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -491,15 +485,14 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+            ssh: false
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-            git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999
@@ -578,15 +571,14 @@ network:
       # Git Repo details which will be used by GitOps/Flux.
       # Do not check-in git_access_token
       gitops:
-        git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+        git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+        ssh: false
         branch: "develop"           # Git branch where release is being made
         release_dir: "platforms/r3-corda-ent/releases/dev" # Relative Path in the Git repo for flux sync per environment. 
         chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-        git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
         username: "git_username"          # Git Service user who has rights to check-in in all branches
         password: "git_access_token"          # Git Server user password/access token
         email: "git_email"                # Email to use in git config
-        private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
       
       # Cordapps Repository details (optional if cordapps jar are store in a repository)
       cordapps:
@@ -616,15 +608,14 @@ network:
             url: "float_vault_addr"
             root_token: "float_vault_root_token"
           gitops:
-            git_ssh: "ssh://git@github.com/<username>/blockchain-automation-framework.git"         # Gitops ssh url for flux value files 
+            git_url: "https://github.com/<username>/blockchain-automation-framework.git"         # Gitops https url for flux value files 
+            ssh: false
             branch: "develop"           # Git branch where release is being made
             release_dir: "platforms/r3-corda-ent/releases/float" # Relative Path in the Git repo for flux sync per environment. 
             chart_source: "platforms/r3-corda-ent/charts"     # Relative Path where the Helm charts are stored in Git repo
-            git_push_url: "github.com/<username>/blockchain-automation-framework.git"   # Gitops https URL for git push 
             username: "git_username"          # Git Service user who has rights to check-in in all branches
             password: "git_access_token"          # Git Server user password/access token
             email: "git_email"                # Email to use in git config
-            private_key: "path_to_private_key"          # Path to private key file which has write-access to the git repo
           ports:
             p2p_port: 40000
             tunnelport: 39999

--- a/platforms/shared/configuration/kubernetes-env-setup.yaml
+++ b/platforms/shared/configuration/kubernetes-env-setup.yaml
@@ -13,11 +13,13 @@
     vars:
       kubeconfig_path: "{{ item.k8s.config_file }}"
       kubecontext: "{{ item.k8s.context }}"
-      git_url: "{{ item.gitops.git_ssh }}"
-      git_key: "{{ item.gitops.private_key }}"
+      git_username: "{{ item.gitops.username }}"
+      git_password: "{{ item.gitops.password }}"
+      git_repo: "{{ item.gitops.git_url.split('//')[1] | lower }}"
       git_branch: "{{ item.gitops.branch }}"
       git_path: "{{ item.gitops.release_dir }}"
-      git_host: "{{ item.gitops.git_push_url.split('/')[0] | lower }}" # extract the hostname from the git_push_url
+      git_host: "{{ item.gitops.git_url.split('/')[2] | lower }}" # extract the hostname from the git_url
+      ssh: "{{ item.gitops.ssh | default(false) }}"
       helm_operator_version: "1.2.0"
     with_items: "{{ network.organizations }}"
   - name: Prepare nodes and clients ports for ambassador

--- a/platforms/shared/configuration/molecule/kubernetes-corda/cleanup.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/cleanup.yml
@@ -8,11 +8,6 @@
     file:
       path: ../../../platforms
       state: absent
-  - name: Delete the known_hosts file
-    file:
-      path: flux_known_hosts
-      state: absent
-  - name: Delete the temp secret file
     file:
       path: test_rsa.pem
       state: absent

--- a/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
@@ -44,11 +44,13 @@
           k8s:
             config_file: "/tmp/molecule/kind-default/kubeconfig"
             context: "kind"
-        git_url: "ssh://git@github.com/hyperledger-labs/blockchain-automation-framework.git"
-        git_key: "test_rsa.pem"
+        git_username: "hyperledger-labs"
+        git_password: "to-be-configured"
+        git_repo: "github.com/hyperledger-labs/blockchain-automation-framework.git"
         git_branch: "develop"
         git_path: "platforms/r3-corda/releases/test"
         git_host: "github.com"
+        ssh: false
         helm_operator_version: "1.2.0"
     - role: setup/ambassador
       vars:

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/cleanup.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/cleanup.yml
@@ -8,10 +8,6 @@
     file:
       path: ../../../platforms
       state: absent
-  - name: Delete the known_hosts file
-    file:
-      path: flux_known_hosts
-      state: absent
   - name: Delete the temp secret file
     file:
       path: test_rsa.pem

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
@@ -44,11 +44,13 @@
           k8s:
             config_file: "/tmp/molecule/kind-default/kubeconfig"
             context: "kind"
-        git_url: "ssh://git@github.com/hyperledger-labs/blockchain-automation-framework.git"
-        git_key: "test_rsa.pem"
+        git_username: "hyperledger-labs"
+        git_password: "to-be-configured"
+        git_repo: "github.com/hyperledger-labs/blockchain-automation-framework.git"
         git_branch: "develop"
         git_path: "platforms/r3-corda/releases/test"
         git_host: "github.com"
+        ssh: false
         helm_operator_version: "1.2.0"      
     - role: setup/ambassador
       vars:

--- a/platforms/shared/configuration/molecule/kubernetes-indy/cleanup.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-indy/cleanup.yml
@@ -8,10 +8,6 @@
     file:
       path: ../../../platforms
       state: absent
-  - name: Delete the known_hosts file
-    file:
-      path: flux_known_hosts
-      state: absent
   - name: Delete the secret file
     file:
       path: test_rsa.pem

--- a/platforms/shared/configuration/molecule/kubernetes-indy/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-indy/converge.yml
@@ -63,11 +63,13 @@
           k8s:
             config_file: "/tmp/molecule/kind-default/kubeconfig"
             context: "kind"
-        git_url: "ssh://git@github.com/hyperledger-labs/blockchain-automation-framework.git"
-        git_key: "test_rsa.pem"
+        git_username: "hyperledger-labs"
+        git_password: "to-be-configured"
+        git_repo: "github.com/hyperledger-labs/blockchain-automation-framework.git"
         git_branch: "develop"
         git_path: "platforms/r3-corda/releases/test"
         git_host: "github.com"
+        ssh: false
         helm_operator_version: "1.2.0"
     - role: setup/ambassador
       vars:

--- a/platforms/shared/configuration/roles/setup/Readme.md
+++ b/platforms/shared/configuration/roles/setup/Readme.md
@@ -75,11 +75,6 @@ This task first creates the HelmRelease Custom resource, and then deploys Flux h
 #### 5. wait for pods to come up
 This checks for the flux Pods to come up. It runs when *flux_service.resources* is not there i.e. flux is not found, until kubectl_get_pods gives a positive result.
 
-#### 6. Get ssh key
-This tasks gets the ssh key. Stores the result in *ssh_key*.
-
-#### 7. Output ssh key
-It outputs the ssh key stored in *ssh_key*.
 
 -------------
 

--- a/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/flux/tasks/main.yaml
@@ -14,12 +14,6 @@
   tags:
     - flux
 
-- name: Get ssh known hosts
-  shell: |
-    ssh-keyscan {{ git_host }} > flux_known_hosts
-    chmod -R 777 flux_known_hosts
-  when: flux_service.resources|length == 0
-
 - name: Helm repo add
   shell: |
     helm repo add fluxcd https://charts.fluxcd.io
@@ -29,11 +23,11 @@
 
 - name: Install flux
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl create secret generic git-auth-{{ network.env.type }} --from-file=identity={{ git_key }} --namespace default
+    KUBECONFIG={{ kubeconfig_path }} kubectl create secret generic git-auth-{{ network.env.type }} --from-literal=GIT_AUTHUSER={{ git_username }}  --from-literal=GIT_AUTHKEY={{ git_password }} --namespace default
     KUBECONFIG={{ kubeconfig_path }} kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/{{ helm_operator_version }}/deploy/crds.yaml --context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }} {{ playbook_dir }}/../../../platforms/shared/charts/flux --namespace default --set git.secretName=git-auth-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='{{ git_url }}' --set git.branch={{ git_branch }} --set git.label='sync-{{ network.env.type }}' --set git.path="{{ git_path }}" --set-file ssh.known_hosts=flux_known_hosts --set registry.insecureHosts="{{ network.docker.url }}" --kube-context="{{ kubecontext }}"
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }}-helm-operator fluxcd/helm-operator --namespace default --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='{{ git_url }}' --set git.ssh.secretName=git-auth-{{ network.env.type }} --set-file git.ssh.known_hosts=flux_known_hosts --set helm.versions=v3 --kube-context="{{ kubecontext }}"
-  when: flux_service.resources|length == 0
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }} {{ playbook_dir }}/../../../platforms/shared/charts/flux --namespace default --set git.secretName=git-auth-{{ network.env.type }} --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='https://{{ git_username }}:{{ git_password }}@{{ git_repo }}' --set git.branch={{ git_branch }} --set git.label='sync-{{ network.env.type }}' --set git.path="{{ git_path }}"  --set registry.insecureHosts="{{ network.docker.url }}" --kube-context="{{ kubecontext }}"
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install flux-{{ network.env.type }}-helm-operator fluxcd/helm-operator --namespace default --set rbac.create=true --set git.timeout=200s --set git.pollInterval=2m --set git.url='https://{{ git_username }}:{{ git_password }}@{{ git_repo }}' --set git.ssh.secretName=git-auth-{{ network.env.type }} --set helm.versions=v3 --kube-context="{{ kubecontext }}"
+  when: flux_service.resources|length == 0 and not ssh
   tags:
     - flux
 
@@ -51,14 +45,3 @@
       - app = flux
       - release = flux-{{ network.env.type }}
   when: flux_service.resources|length == 0
-
-- name: Get ssh key
-  shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl -n default logs deployment/flux-{{ network.env.type }} | grep identity.pub | cut -d '"' -f2
-  register: ssh_key
-  changed_when: false
-
-- name: Output ssh key
-  debug:
-    var: ssh_key.stdout
-  changed_when: false


### PR DESCRIPTION
Signed-off-by: srinivasan.sankaran <srinivasan.sankaran@accenture.com>

**Changelog**
- Updated template, roles, molecule test, and network YAML references to HTTPS from ssh for r3-corda-ent.
- Updated the shared/setup readme file to reflect recent flux changes.
- Updated shared/setup/flux role to use git username, password and URL for HTTPS.
- Removed references of ssh from setup/flux/role.
- Removed git push URL from network.yaml and references.
- Updated the vars of the role from where shared/flux/setup role is called for r3-corda-ent.
- Removed unwanted console log from quorum container controller.


 

**Reviewed by**
@suvajit-sarkar 

 

**Linked issue**
#1220 
