### PR TITLE
[shared] Fixes issue where loadBalancerSourceRanges IP values where i…

### DIFF
--- a/docs/source/operations/besu_networkyaml.md
+++ b/docs/source/operations/besu_networkyaml.md
@@ -42,7 +42,7 @@ The snapshot of the `env` section with example value is below
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'  
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 50                # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```
@@ -53,6 +53,7 @@ The fields under `env` section are
 | type       | Environment type. Can be like dev/test/prod.|
 | proxy      | Choice of the Cluster Ingress controller. Currently supports 'ambassador' only as 'haproxy' has not been implemented for Hyperledger Besu |
 | ambassadorPorts   | Any additional Ambassador ports can be given here; must be comma-separated without spaces like `10010,10020`. This is only valid if `proxy: ambassador`. These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports to be opened on Ambassador. Our sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified in the `organization` section.     |
+| loadBalancerSourceRanges | (Optional) Restrict inbound access to a single or list of IP adresses for the public Ambassador ports to enhance BAF network security. This is only valid if `proxy: ambassador`.  |
 | retry_count       | Retry count for the checks. Use a high number if your cluster is slow. |
 |external_dns       | If the cluster has the external DNS service, this has to be set `enabled` so that the hosted zone is automatically updated. |
 

--- a/docs/source/operations/corda_networkyaml.md
+++ b/docs/source/operations/corda_networkyaml.md
@@ -42,7 +42,7 @@ The snapshot of the `env` section with example values is below
     type: "env-type"                # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```
@@ -53,6 +53,7 @@ The fields under `env` section are
 | type       | Environment type. Can be like dev/test/prod.|
 | proxy      | Choice of the Cluster Ingress controller. Currently supports `ambassador` only as `haproxy` has not been implemented for Corda |
 | ambassadorPorts   | Any additional Ambassador ports can be given here; must be comma-separated without spaces like `15010,15020`. This is only valid if `proxy: ambassador`     |
+| loadBalancerSourceRanges | (Optional) Restrict inbound access to a single or list of IP adresses for the public Ambassador ports to enhance BAF network security. This is only valid if `proxy: ambassador`.  |
 | retry_count       | Retry count for the checks. Use a large number if your kubernetes cluster is slow. |
 | external_dns       | If the cluster has the external DNS service, this has to be set `enabled` so that the hosted zone is automatically updated. |
 

--- a/docs/source/operations/fabric_networkyaml.md
+++ b/docs/source/operations/fabric_networkyaml.md
@@ -44,7 +44,7 @@ The snapshot of the `env` section with example value is below
     type: "env_type"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'none' (for minikube)
     ambassadorPorts: 15010,15020    # is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 100                # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```
@@ -55,6 +55,7 @@ The fields under `env` section are
 | type       | Environment type. Can be like dev/test/prod.|
 | proxy      | Choice of the Cluster Ingress controller. Currently supports 'haproxy' only as 'ambassador' has not been implemented for Fabric |
 | ambassadorPorts   | Any additional Ambassador ports can be given here; must be comma-separated without spaces like `10010,10020`. This is only valid if `proxy: ambassador`     |
+| loadBalancerSourceRanges | (Optional) Restrict inbound access to a single or list of IP adresses for the public Ambassador ports to enhance BAF network security. This is only valid if `proxy: ambassador`.  |
 | retry_count       | Retry count for the checks. |
 |external_dns       | If the cluster has the external DNS service, this has to be set `enabled` so that the hosted zone is automatically updated. |
 

--- a/docs/source/operations/indy_networkyaml.md
+++ b/docs/source/operations/indy_networkyaml.md
@@ -42,7 +42,7 @@ The snapshot of the `env` section with example values is below
     # Any additional Ambassador ports can be given below, must be comma-separated without spaces. 
     # Must be different from all steward ambassador ports specified in the rest of this network yaml
     ambassadorPorts: 15010,15020,15030,15040 
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: disabled           # Should be enabled if using external-dns for automatic route configuration
 ```
@@ -53,6 +53,7 @@ The fields under `env` section are
 | type       | Environment type. Can be like dev/test/prod.|
 | proxy      | Choice of the Cluster Ingress controller. Currently supports 'ambassador' only as 'haproxy' has not been implemented for Indy |
 |ambassadorPorts|Provide additional Ambassador ports for Identity sample app, must be comma-separated without spaces. These ports must be different from all steward ambassador ports specified in the rest of this network yaml |
+| loadBalancerSourceRanges | (Optional) Restrict inbound access to a single or list of IP adresses for the public Ambassador ports to enhance BAF network security. This is only valid if `proxy: ambassador`.  |
 | retry_count       | Retry count for the checks.|
 | external_dns       | If the cluster has the external DNS service, this has to be set `enabled` so that the hosted zone is automatically updated. Must be `enabled` for Identity sample app.  |
 

--- a/docs/source/operations/quorum_networkyaml.md
+++ b/docs/source/operations/quorum_networkyaml.md
@@ -46,7 +46,7 @@ The snapshot of the `env` section with example value is below
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'  
+    loadBalancerSourceRanges: 0.0.0.0/0 # Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'  
     retry_count: 50                # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 ```
@@ -57,6 +57,7 @@ The fields under `env` section are
 | type       | Environment type. Can be like dev/test/prod.|
 | proxy      | Choice of the Cluster Ingress controller. Currently supports 'ambassador' only as 'haproxy' has not been implemented for Quorum |
 | ambassadorPorts   | Any additional Ambassador ports can be given here; must be comma-separated without spaces like `10010,10020`. This is only valid if `proxy: ambassador`. These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports to be opened on Ambassador. Our sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified in the `organization` section.     |
+| loadBalancerSourceRanges | Restrict inbound access to a single or list of IP adresses for the public Ambassador ports to enhance BAF network security. This is only valid if `proxy: ambassador`.  |
 | retry_count       | Retry count for the checks. Use a high number if your cluster is slow. |
 |external_dns       | If the cluster has the external DNS service, this has to be set `enabled` so that the hosted zone is automatically updated. |
 

--- a/platforms/hyperledger-besu/configuration/samples/network-besu-newnode.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu-newnode.yaml
@@ -15,7 +15,7 @@ network:
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 3 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15014,15015,15016,15017,15020,15021,15022,15030,15031,15032,15040,15041,15042,15050,15051,15052
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'  
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
+++ b/platforms/hyperledger-besu/configuration/samples/network-besu.yaml
@@ -15,7 +15,7 @@ network:
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 3 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15014,15015,15016,15017,15020,15021,15022,15030,15031,15032,15040,15041,15042,15050,15051,15052
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador' 
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-new-channel.yaml
@@ -13,6 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-add-organization.yaml
@@ -13,7 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabric-remove-organization.yaml
@@ -13,6 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv-add-peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv-add-peer.yaml
@@ -13,7 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft-add-orderer.yaml
@@ -13,7 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2-raft.yaml
@@ -13,7 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
+++ b/platforms/hyperledger-fabric/configuration/samples/network-fabricv2.yaml
@@ -13,7 +13,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: haproxy                  # values can be 'haproxy' or 'ambassador'
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-indy/configuration/samples/network-indy-newnode.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-indy-newnode.yaml
@@ -15,7 +15,8 @@
       proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Indy
       # Any additional Ambassador ports can be given below, must be comma-separated without spaces. 
       # Must be different from all other ports specified in the rest of this network yaml
-      ambassadorPorts: 15110,15123,15124,15133,15134,15143,15144 
+      ambassadorPorts: 15110,15123,15124,15133,15134,15143,15144
+      loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
       retry_count: 40                 # Retry count for the checks
       external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/hyperledger-indy/configuration/samples/network-indyv3-aries.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-indyv3-aries.yaml
@@ -15,7 +15,7 @@ network:
     # Any additional Ambassador ports can be given below, must be comma-separated without spaces. 
     # Must be different from all stward ambassador ports specified in the rest of this network yaml
     ambassadorPorts: 15010,15023,15024,15033,15034,15043,15044
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled          # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/hyperledger-indy/configuration/samples/network-indyv3.yaml
+++ b/platforms/hyperledger-indy/configuration/samples/network-indyv3.yaml
@@ -18,7 +18,7 @@ network:
     # Any additional Ambassador ports can be given below, must be comma-separated without spaces. 
     # Must be different from all other ports specified in the rest of this network yaml
     ambassadorPorts: 15010,15023,15024,15033,15034,15043,15044
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador' 
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
 

--- a/platforms/quorum/configuration/samples/network-quorum-newnode.yaml
+++ b/platforms/quorum/configuration/samples/network-quorum-newnode.yaml
@@ -15,7 +15,7 @@ network:
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'   
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/quorum/configuration/samples/network-quorum.yaml
+++ b/platforms/quorum/configuration/samples/network-quorum.yaml
@@ -15,7 +15,7 @@ network:
     #  These ports are enabled per cluster, so if you have multiple clusters you do not need so many ports
     #  This sample uses a single cluster, so we have to open 4 ports for each Node. These ports are again specified for each organization below
     ambassadorPorts: 15010,15011,15012,15013,15020,15021,15022,15023,15030,15031,15032,15033,15040,15041,15042,15043
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'   
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks on Kubernetes cluster
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
+++ b/platforms/r3-corda-ent/configuration/samples/network-cordaent.yaml
@@ -15,7 +15,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
     ambassadorPorts: 15010,15020,15021,15030,15031,15040,15041,15050,15051  # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador'
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/r3-corda/configuration/samples/network-cordav2.yaml
+++ b/platforms/r3-corda/configuration/samples/network-cordav2.yaml
@@ -14,7 +14,7 @@ network:
     type: "dev"              # tag for the environment. Important to run multiple flux on single cluster
     proxy: ambassador               # value has to be 'ambassador' as 'haproxy' has not been implemented for Corda
     ambassadorPorts: 15010,15020    # Any additional Ambassador ports can be given here, must be comma-separated without spaces, this is valid only if proxy='ambassador'
-    loadBalancerSourceRanges: ""    # (Optional) Add IP addresses/ranges to limit access to inbound ambassador ports, this is valid only if proxy='ambassador' 
+    loadBalancerSourceRanges: # (Optional) Default value is '0.0.0.0/0', this value can be changed to any other IP adres or list (comma-separated without spaces) of IP adresses, this is valid only if proxy='ambassador'
     retry_count: 20                 # Retry count for the checks
     external_dns: enabled           # Should be enabled if using external-dns for automatic route configuration
   

--- a/platforms/shared/charts/ambassador/templates/service.yaml
+++ b/platforms/shared/charts/ambassador/templates/service.yaml
@@ -51,9 +51,15 @@ metadata:
   {{- end }}
 spec:
   type: LoadBalancer
-{{- if .Values.ambassador.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ .Values.ambassador.loadBalancerSourceRanges }}
-{{- end }} 
+{{- if first .Values.ambassador.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: 
+{{- range .Values.ambassador.loadBalancerSourceRanges }}
+   - {{ . }} 
+{{- end }}
+{{- else }}
+  loadBalancerSourceRanges: 
+  - 0.0.0.0/0
+{{- end }}  
   externalTrafficPolicy: Local
   ports:
    - port: {{ .Values.ambassador.port }}

--- a/platforms/shared/charts/ambassador/values.yaml
+++ b/platforms/shared/charts/ambassador/values.yaml
@@ -4,7 +4,7 @@ ambassador:
   port: "8443"
   image: quay.io/datawire/ambassador
   tag: "1.3.2"
-  loadBalancerSourceRanges:
+  loadBalancerSourceRanges: 
   otherPorts:
     - 10020
     - 10010

--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -49,7 +49,7 @@
     - notest
 - name: Install Ambassador with EIP for Indy
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ terminal.stdout }},{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }}
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ terminal.stdout }},{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} --set ambassador.loadBalancerSourceRanges={"{{ network.env.loadBalancerSourceRanges | default('0.0.0.0/0') }}"} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador 
   tags:
     - ambassador
     - molecule-idempotence-notest
@@ -59,7 +59,7 @@
 
 - name: Install Ambassador with EIP for Besu
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }} 
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} --set ambassador.loadBalancerSourceRanges={"{{ network.env.loadBalancerSourceRanges | default('0.0.0.0/0') }}"} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador  
   tags:
     - ambassador
     - molecule-idempotence-notest
@@ -69,7 +69,7 @@
 
 - name: Install Ambassador for Corda/Quorum
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }}
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} --set ambassador.loadBalancerSourceRanges={"{{ network.env.loadBalancerSourceRanges | default('0.0.0.0/0') }}"} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador 
   tags:
     - ambassador
     - molecule-idempotence-notest
@@ -77,7 +77,7 @@
 
 - name: Install Ambassador for Fabric
   shell: |
-    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.grpc=enabled --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador --set ambassador.loadBalancerSourceRanges={{ network.env.loadBalancerSourceRanges | default("") }}
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default --set ambassador.otherPorts={"{{ network.env.ambassadorPorts }}"} --set ambassador.grpc=enabled --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} --set ambassador.loadBalancerSourceRanges={"{{ network.env.loadBalancerSourceRanges | default('0.0.0.0/0') }}"} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador 
   tags:
     - ambassador
     - molecule-idempotence-notest


### PR DESCRIPTION
…ncorrectly read causing BAF to crash

Signed-off-by: jwavoetacn <68590662+jwavoetacn@users.noreply.github.com>

**Changelog**
- Fix: If-statement to check user input and default to 0.0.0.0/0 when given "" or null/nil   
- Fix: Default value of 0.0.0.0/0 will be used if variable is missing from the network.yaml  
- Update: Comments and documentation updated to explain to user that 'loadBalancerSourceRanges' is a optional field

**Tests and results**

`loadBalancerSourceRanges:`  --> Default value (0.0.0.0/0) is used
`loadBalancerSourceRanges: ""`  --> Default value (0.0.0.0/0) is used
`loadBalancerSourceRanges:` missing from network.yaml --> Default value (0.0.0.0/0) is used
`loadBalancerSourceRanges: 1.1.1.1/32` --> Value 1.1.1.1/32 used in the AWS Security Groups
`loadBalancerSourceRanges: 1.1.1.1/32,2.2.2.2/32` --> Value 1.1.1.1/32 & 2.2.2.2/32 used in the AWS Security Groups
`loadBalancerSourceRanges: 1.1.1.1/32,2.2.2.2/32,3.3.3.3/32` --> Value 1.1.1.1/32 , 2.2.2.2/32 & 3.3.3.3/32 used in the AWS Security Groups

**To be reviewed by**
@suvajit-sarkar @sauveergoel

**Linked issue**
#1243 
