### PR TITLE
Fix the CA certificate being mapped to TLSCA certificate

### DIFF
--- a/platforms/hyperledger-fabric/charts/anchorpeer/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/anchorpeer/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
   CORE_PEER_ADDRESS: {{ $.Values.peer.address }}
   CORE_PEER_LOCALMSPID: {{ $.Values.peer.localmspid }}
   CORE_PEER_TLS_ENABLED: "{{ $.Values.peer.tlsstatus }}"
-  CORE_PEER_TLS_ROOTCERT_FILE: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+  CORE_PEER_TLS_ROOTCERT_FILE: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
   ORDERER_CA: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
   ORDERER_URL: {{ $.Values.orderer.address }}
   CORE_PEER_MSPCONFIGPATH: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp

--- a/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/approve_chaincode/templates/approve_chaincode.yaml
@@ -162,7 +162,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ $.Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL

--- a/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/commit_chaincode/templates/commit_chaincode.yaml
@@ -216,7 +216,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ $.Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL

--- a/platforms/hyperledger-fabric/charts/create_channel/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/create_channel/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
   CORE_PEER_ADDRESS: {{ $.Values.peer.address }}
   CORE_PEER_LOCALMSPID: {{ $.Values.peer.localmspid }}
   CORE_PEER_TLS_ENABLED: "{{ $.Values.peer.tlsstatus }}"
-  CORE_PEER_TLS_ROOTCERT_FILE: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+  CORE_PEER_TLS_ROOTCERT_FILE: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
   ORDERER_CA: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
   ORDERER_URL: {{ $.Values.orderer.address }}
   CORE_PEER_MSPCONFIGPATH: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp

--- a/platforms/hyperledger-fabric/charts/fabric_cli/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric_cli/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ .Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL

--- a/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/install_chaincode/templates/install_chaincode.yaml
@@ -254,7 +254,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ $.Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL

--- a/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/instantiate_chaincode/templates/instantiate_chaincode.yaml
@@ -101,16 +101,19 @@ spec:
           CACERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["cacerts"]')
           KEYSTORE=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["keystore"]')
           SIGNCERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["signcerts"]')
+          TLSCACERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tlscacerts"]')
 
           mkdir -p ${OUTPUT_PATH}/admincerts
           mkdir -p ${OUTPUT_PATH}/cacerts
           mkdir -p ${OUTPUT_PATH}/keystore
           mkdir -p ${OUTPUT_PATH}/signcerts
+          mkdir -p ${OUTPUT_PATH}/tlscacerts
 
           echo "${ADMINCERT}" >> ${OUTPUT_PATH}/admincerts/admin.crt
           echo "${CACERTS}" >> ${OUTPUT_PATH}/cacerts/ca.crt
           echo "${KEYSTORE}" >> ${OUTPUT_PATH}/keystore/server.key
           echo "${SIGNCERTS}" >> ${OUTPUT_PATH}/signcerts/server.crt
+          echo "${TLSCACERTS}" >> ${OUTPUT_PATH}/tlscacerts/tlsca.crt
         volumeMounts:
         {{ if .Values.vault.tls  }}
         - name: vaultca
@@ -149,7 +152,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ $.Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL

--- a/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/invoke_chaincode/templates/invoke_chaincode.yaml
@@ -217,7 +217,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ $.Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL

--- a/platforms/hyperledger-fabric/charts/join_channel/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
   CORE_PEER_ADDRESS: {{ $.Values.peer.address }}
   CORE_PEER_LOCALMSPID: {{ $.Values.peer.localmspid }}
   CORE_PEER_TLS_ENABLED: "{{ $.Values.peer.tlsstatus }}"
-  CORE_PEER_TLS_ROOTCERT_FILE: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+  CORE_PEER_TLS_ROOTCERT_FILE: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
   ORDERER_CA: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
   ORDERER_URL: {{ $.Values.orderer.address }}
   CORE_PEER_MSPCONFIGPATH: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp

--- a/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
+++ b/platforms/hyperledger-fabric/charts/join_channel/templates/join_channel.yaml
@@ -98,16 +98,19 @@ spec:
           CACERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["cacerts"]')
           KEYSTORE=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["keystore"]')
           SIGNCERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["signcerts"]')
+          TLSCACERTS=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tlscacerts"]')
 
           mkdir -p ${OUTPUT_PATH}/admincerts
           mkdir -p ${OUTPUT_PATH}/cacerts
           mkdir -p ${OUTPUT_PATH}/keystore
           mkdir -p ${OUTPUT_PATH}/signcerts
+          mkdir -p ${OUTPUT_PATH}/tlscacerts
 
           echo "${ADMINCERT}" >> ${OUTPUT_PATH}/admincerts/admin.crt
           echo "${CACERTS}" >> ${OUTPUT_PATH}/cacerts/ca.crt
           echo "${KEYSTORE}" >> ${OUTPUT_PATH}/keystore/server.key
           echo "${SIGNCERTS}" >> ${OUTPUT_PATH}/signcerts/server.crt
+          echo "${TLSCACERTS}" >> ${OUTPUT_PATH}/tlscacerts/tlsca.crt
         volumeMounts:
         {{ if .Values.vault.tls  }}
         - name: vaultca

--- a/platforms/hyperledger-fabric/charts/peernode/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
   CORE_PEER_TLS_ENABLED: "{{ $.Values.peer.tlsstatus }}"
   CORE_PEER_TLS_CERT_FILE: /etc/hyperledger/fabric/crypto/tls/server.crt
   CORE_PEER_TLS_KEY_FILE: /etc/hyperledger/fabric/crypto/tls/server.key
-  CORE_PEER_TLS_ROOTCERT_FILE: /etc/hyperledger/fabric/crypto/tls/ca.crt
+  CORE_PEER_TLS_ROOTCERT_FILE: /etc/hyperledger/fabric/crypto/msp/tlscacerts/tlsca.crt
   CORE_PEER_GOSSIP_USELEADERELECTION: "true"
   CORE_PEER_GOSSIP_ORGLEADER: "false"
   CORE_PEER_PROFILE_ENABLED: "true"

--- a/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/upgrade_chaincode/templates/upgrade_chaincode.yaml
@@ -147,7 +147,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ $.Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL

--- a/platforms/hyperledger-fabric/charts/verify_chaincode/templates/verify_chaincode.yaml
+++ b/platforms/hyperledger-fabric/charts/verify_chaincode/templates/verify_chaincode.yaml
@@ -151,7 +151,7 @@ spec:
         - name: CORE_PEER_TLS_ENABLED
           value: "{{ $.Values.peer.tlsstatus }}"
         - name: CORE_PEER_TLS_ROOTCERT_FILE
-          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/cacerts/ca.crt
+          value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/admin/msp/tlscacerts/tlsca.crt
         - name: ORDERER_CA
           value: /opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt
         - name: ORDERER_URL


### PR DESCRIPTION
**Changelog**
- Updated paths to get the TLS CA instead of the CA for CORE_PEER_TLS_ROOTCERT_FILE 


**Reviewed by**
@suvajit-sarkar 
@jagpreetsinghsasan 

 

**Linked issue**
#1263 
