### PR TITLE
[ Fabric ] New Org is added to existing consortium and to the existing channel

### DIFF
--- a/platforms/hyperledger-fabric/configuration/add-organization.yaml
+++ b/platforms/hyperledger-fabric/configuration/add-organization.yaml
@@ -93,8 +93,8 @@
         component_type: "{{ item.type | lower}}"
         orderers: "{{ item.services.orderers }}"
       loop: "{{ network['organizations'] }}"
-      when: item.org_status == 'new'
-    
+      when: item.org_status == 'new'  
+      
     # Generate script to modify the fetched configuration block
     - include_role:
         name: "create/new_organization/create_block"
@@ -144,20 +144,25 @@
         build_path: "./build"
         genesis: "{{ item.genesis }}"
         channel_name: "{{ item.channel_name | lower}}"
-        profile_name: "{{ item.channel_name }}"
         fetch_certs: "false"
+        profile_name: "{{ item.channel_name }}"
       loop: "{{ network['channels'] }}"
 
-    # This role is to start the existing peer cli
-    # Fetch the configuration block and modify the block
+    # This role adds the new org to the existing consortium and updates the block  
+    
     - include_role:
-        name: "setup/config_block/fetch"
+        name: "create/new_organization/syschannel_block"
       vars:
         build_path: "./build"
-        participants: "{{ item.participants }}"
+        orderers: "{{ org.services.orderers }}"
         docker_url: "{{ network.docker.url }}"
-      loop: "{{ network['channels'] }}"
-    
+        channel_name: "syschannel"
+        update_type: "tls"
+      loop: "{{ network.organizations }}"
+      loop_control:
+        loop_var: org
+      when: org.type == 'orderer' 
+
     # This role creates the value file for peers of organisations and write couch db credentials
     # to the vault.
     - include_role:
@@ -176,14 +181,26 @@
       loop: "{{ network['organizations'] }}"
       when: item.type == 'peer' and item.org_status == 'new'
 
-    # This role fetch the block from the ansible host and get it signed from each existing organization admin
+
+    # This role is to start the existing peer cli
+    # Fetch the configuration block and modify the block
     - include_role:
-        name: "setup/config_block/sign_and_update"
+        name: "setup/config_block/fetch"
       vars:
         build_path: "./build"
         participants: "{{ item.participants }}"
         docker_url: "{{ network.docker.url }}"
       loop: "{{ network['channels'] }}"
+
+     # This role fetch the block from the ansible host and get it signed from each existing organization admin
+    - include_role:
+        name: "setup/config_block/sign_and_update"
+      vars:
+        build_path: "./build"
+        channel_sys: "syschannel"
+        participants: "{{ item.participants }}"
+        docker_url: "{{ network.docker.url }}"
+      loop: "{{ network['channels'] }}"      
 
     # This role fetches block 0 and joins peers of new organizaion to the channel
     - include_role:
@@ -192,10 +209,11 @@
         build_path: "./build"
         participants: "{{ item.participants }}"
         docker_url: "{{ network.docker.url }}"
-      loop: "{{ network['channels'] }}"
+      loop: "{{ network['channels'] }}"  
 
     # Create CLI pod for peers with cli option enabled
-    - include_role:
+    - name: Create CLI pod for each peer with it enabled
+      include_role:
         name: "create/cli_pod"
       vars:
         peers: "{{ org.services.peers }}"
@@ -203,7 +221,7 @@
       loop: "{{ network.organizations }}"
       loop_control:
         loop_var: org
-      when: org.type == "peer" and org.org_status == "new"
+      when: org.type == 'peer' and org.org_status == 'new'
 
   vars: #These variables can be overriden from the command line
     privilege_escalate: false           #Default to NOT escalate to root privledges

--- a/platforms/hyperledger-fabric/configuration/roles/create/cli_pod/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/cli_pod/tasks/main.yaml
@@ -44,4 +44,7 @@
     GIT_BRANCH: "{{ org.gitops.branch }}"
     GIT_RESET_PATH: "platforms/hyperledger-fabric/configuration"
     msg: "[ci skip] Pushing CLI value files"
-  when: peer.cli is defined and peer.cli == "enabled" 
+  loop: "{{ peers }}"
+  loop_control:
+    loop_var: peer    
+  when: peer.cli is defined and peer.cli == "enabled"

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/main.yaml
@@ -207,7 +207,7 @@
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
-  when: vault_admin_result.failed == True
+  when: vault_admin_result.failed == True or vault_admin_result.stdout == ''
 
 # Check user msp already created
 - name: Check if user msp already created
@@ -227,4 +227,4 @@
   environment:
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
-  when: vault_user_result.failed == True
+  when: vault_user_result.failed == True or vault_user_result.stdout == ''

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/create_block/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/create_block/tasks/main.yaml
@@ -24,6 +24,7 @@
     dest: "./build/create-block-{{ channel_name }}.sh"
   vars:
     component_name: "{{ participant.name | lower }}"
+    orderer_address: " {{ participant.ordererAddress }} "
     os: "{{ fabric.os }}"
     arch: "{{ fabric.arch }}"
     version: "{{ network.version }}"

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/main.yaml
@@ -1,0 +1,28 @@
+############################################################################################
+# This task creates the generate_block.sh file for new organizations
+- name: "Create create-syschannel-block.sh script file for new orderer"
+  template:
+    src: "syschannel_update_script.tpl"
+    dest: "./build/syschannel-update-script.sh"
+  vars:
+    component_name: "{{ org.name | lower }}"
+    new_org_query: "organizations[?org_status=='new']"
+    new_org: "{{ network | json_query(new_org_query) | first }}"
+    channel: "{{ network.channels | first }}"
+    os: "{{ fabric.os }}"
+    arch: "{{ fabric.arch }}"
+    version: "{{ network.version }}"
+
+
+# This task calls nested_create_cli to generate the cli value files for the orderer organization
+- name: Call nested_create_cli for the first orderer
+  include_tasks: nested_create_cli.yaml
+  vars:
+    orderer: "{{ org.services.orderers | first }}"
+    new_org_query: "participants[?org_status=='new']"
+    channel: "{{ chann }}"
+    new_org: "{{ chann | json_query(new_org_query) | first }}"
+  loop: "{{ network.channels }}"
+  loop_control:
+    loop_var: chann
+  when: new_org != ""

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/nested_create_cli.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/tasks/nested_create_cli.yaml
@@ -1,0 +1,72 @@
+############################################################################################
+# This task creates the orderer cli and fetch and modify the config block
+############################################################################################
+
+# Create the value file for creater org first peer
+- name: "create valuefile for cli {{ orderer.name }}-{{ org.name }}-{{ channel_name }}"
+  include_role:
+    name: k8_component
+  vars:
+    component_type_name: "{{ org.name | lower }}"
+    component_type: "orderer_cli_job"    
+    component_name: "cli-{{ channel_name }}-{{ org.name }}-{{ orderer.name }}"
+    orderer_name: "{{ orderer.name }}"
+    component_ns: "{{ org.name | lower}}-net"
+    git_url: "{{ org.gitops.git_url }}"
+    git_branch: "{{ org.gitops.branch }}"
+    charts_dir: "{{ org.gitops.chart_source }}"
+    vault: "{{ org.vault }}"
+    fabrictools_image: "hyperledger/fabric-tools:{{ network.version }}"
+    alpine_image: "{{ docker_url }}/alpine-utils:1.0"
+    channel_name: "{{ channel_name }}"
+    storage_class: "{{ org.name }}sc"
+    release_dir: "{{playbook_dir}}/../../../{{org.gitops.release_dir}}"
+    orderer_component: "{{ orderer.name | lower }}.{{ org.name | lower }}-net"
+    orderer_address: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+
+
+# Start the cli using the value file created in the previous step
+- name: "start cli"
+  shell: |
+    KUBECONFIG={{ org.k8s.config_file }} helm upgrade --install -f {{playbook_dir}}/../../../{{org.gitops.release_dir}}/{{ org.name }}/orderer_cli_job.yaml {{ orderer.name }}-{{ org.name }}-cli {{playbook_dir}}/../../../{{org.gitops.chart_source}}/fabric_cli
+
+# waiting for fabric cli
+- name: "Check if fabric cli is present"
+  k8s_info:
+    kind: Pod
+    namespace: "{{ org.name }}-net"
+    kubeconfig: "{{ org.k8s.config_file }}"
+    context: "{{ org.k8s.context }}"
+    label_selectors:
+      - app = cli
+  register: get_cli
+  until: ("Running" in get_cli|json_query('resources[*].status.phase'))
+  retries: "{{ network.env.retry_count}}"
+  delay: 40
+
+############################################################################################
+# This task fetch , modify, update and copy the configuration block from the blockchain with the new orderer information
+# from orderer cli
+- name: fetch, modify, update and copy the configuration block from the blockchain
+  shell: |
+    export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "cli" | head -n 1 | awk '{print $1}')
+    KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel fetch config {{ channel_name }}_config_block.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
+    KUBECONFIG={{ kubernetes.config_file }} kubectl cp ./build/syschannel-update-script.sh {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/update_consenter.sh
+    KUBECONFIG={{ kubernetes.config_file }} kubectl cp ./build/channel-artifacts/{{ channel_name | lower}}-orderer {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/orderer
+    KUBECONFIG={{ kubernetes.config_file }} kubectl cp ./build/channel-artifacts/{{ channel.channel_name | lower }}.json {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/config.json
+    KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- chmod 777 ./update_consenter.sh
+    KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} --  sh ./update_consenter.sh
+    KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel update -f {{ channel_name }}_diff_config_envelope.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
+    KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel fetch config {{ channel_name }}_config_block_latest.pb -o {{ ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
+    KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name | lower }}_config_block_latest.pb ./build/{{ channel_name | lower }}_config_block.pb
+    KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name | lower }}_updated_config.json ./build/{{ channel.channel_name | lower }}_config_block_with_added_content.json  
+  environment:
+    ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
+  vars: 
+    kubernetes: "{{ org.k8s }}"
+    ordererAddress: "{{ orderer.name | lower }}.{{ org.external_url_suffix }}:8443"
+
+# Delete the orderer cli   
+- name: "delete cli {{ orderer.name }}-{{ org.name }}-cli"
+  shell: |
+    KUBECONFIG={{ org.k8s.config_file }} helm uninstall {{ orderer.name }}-{{ org.name }}-cli

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/templates/syschannel_update_script.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/templates/syschannel_update_script.tpl
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -x
+
+CURRENT_DIR=${PWD}
+
+echo "installing jq "
+apt-get install -y jq
+echo "installing configtxlator"
+mkdir temp
+cd temp/
+wget https://github.com/hyperledger/fabric/releases/download/v{{ version }}/hyperledger-fabric-{{ os }}-{{ arch }}-{{ version }}.tar.gz
+tar -xvf hyperledger-fabric-{{ os }}-{{ arch }}-{{ version }}.tar.gz
+mv bin/configtxlator ../
+cd ../
+rm -r temp
+echo "converting the channel_config_block.pb to channel_config.json using configtxlator and jq"
+configtxlator proto_decode --input {{ channel_name }}_config_block.pb --type common.Block | jq .data.data[0].payload.data.config > {{ channel_name }}_config_block.json
+echo "adding new organization crypto material from config.json to the channel_config.json to make channel_modified_config.json"
+echo "adding org to the existing consortium"
+jq -s '.[0] * {"channel_group":{"groups":{"Consortiums":{"groups": {"{{ channel.consortium }}": {"groups": {"{{ new_org.name | lower }}MSP":.[1]}}}}}}}' {{ channel_name }}_config_block.json ./config.json >& {{ channel_name }}_updated_config.json
+configtxlator proto_encode --input {{ channel_name }}_config_block.json --type common.Config --output {{ channel_name }}_config.pb
+configtxlator proto_encode --input {{ channel_name }}_updated_config.json --type common.Config --output {{ channel_name }}_updated_config.pb
+echo "calculate the delta between these two config protobufs using configtxlator"
+configtxlator compute_update --channel_id {{ channel_name }} --original {{ channel_name }}_config.pb --updated {{ channel_name }}_updated_config.pb --output {{ channel_name }}_diff_config.pb
+echo "decode the channel_update.pb to json to add headers."
+configtxlator proto_decode --input {{ channel_name }}_diff_config.pb --type common.ConfigUpdate | jq . > {{ channel_name }}_diff_config.json
+echo "wrapping the headers arround the channel_update.json file and create channel_update_in_envelope.json"
+echo '{"payload":{"header":{"channel_header":{"channel_id":"{{ channel_name | lower }}", "type":2}},"data":{"config_update":'$(cat {{ channel_name }}_diff_config.json)'}}}' | jq . > {{ channel_name }}_diff_config_envelope.json
+echo "converting the channel_update_in_envelope.json to channel_update_in_envelope.pb"
+configtxlator proto_encode --input {{ channel_name }}_diff_config_envelope.json --type common.Envelope --output {{ channel_name }}_diff_config_envelope.pb
+mv {{ channel_name }}_config_block.pb {{ channel_name }}_config_block_old.pb
+cd ${CURRENT_DIR}

--- a/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/vars/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/new_organization/syschannel_block/vars/main.yaml
@@ -1,0 +1,5 @@
+---
+tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
+fabric:
+  os: "linux"   # use "darwin" for MacOS X, "windows" for Windows
+  arch: "amd64" # other possible values: "386","arm64","arm","ppc64le","s390x"

--- a/platforms/hyperledger-fabric/configuration/roles/setup/config_block/fetch/tasks/nested_fetch_role.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/config_block/fetch/tasks/nested_fetch_role.yaml
@@ -44,12 +44,12 @@
   shell: |
     export PEER_CLI=$(KUBECONFIG={{ org.k8s.config_file }} kubectl get po -n {{ org.name }}-net | grep "cli" | head -n 1 | awk '{print $1}')
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- peer channel fetch config {{ channel_name }}_config_block.pb -o {{ participantx.ordererAddress }} -c {{ channel_name }} --tls --cafile ${ORDERER_CA}
-    KUBECONFIG={{ kubernetes.config_file }} kubectl cp ./build/create-block-{{ channel_name }}.sh {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/create_block.sh
+    KUBECONFIG={{ kubernetes.config_file }} kubectl cp ./build/create-block-{{ channel_name | lower }}.sh {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/create_block.sh
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp ./build/channel-artifacts/{{ channel_name | lower }}.json {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/config.json
     KUBECONFIG={{ kubernetes.config_file }} kubectl cp ./build/channel-artifacts/{{ channel_name | lower}}-anchorfile.json {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/anchorfile.json
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} -- chmod 777 ./create_block.sh
     KUBECONFIG={{ kubernetes.config_file }} kubectl exec -n {{ org.name }}-net ${PEER_CLI} --  sh ./create_block.sh
-    KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name }}_update_in_envelope.pb ./build/{{ channel_name | lower}}_config_block.pb
+    KUBECONFIG={{ kubernetes.config_file }} kubectl cp {{ org.name }}-net/${PEER_CLI}:/opt/gopath/src/github.com/hyperledger/fabric/peer/{{ channel_name | lower }}_update_in_envelope.pb ./build/{{ channel_name | lower}}_config_block.pb
   environment:
     ORDERER_CA: "/opt/gopath/src/github.com/hyperledger/fabric/crypto/orderer/tls/ca.crt"
   vars: 

--- a/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/setup/config_block/sign_and_update/tasks/main.yaml
@@ -24,7 +24,7 @@
   loop: "{{ participants }}"
   loop_control:
     loop_var: participant
-  when: participant.type != 'creator'
+  when: participant.type != 'creator' and participant.org_status != 'new'
 
 # Creator signs the config block and updates the channel with latest config block  
 - name: Call nested_update_channel for the peer


### PR DESCRIPTION


Signed-off-by: alvaropicazo <alvaro.picazo.haase@accenture.com>

**Changelog**
- Added new setup/genesis folder where the genesis block is updated by the orderer using syschannel to add the org to the existing consortium
- Fixed the creation of a new anchorpeer for the new org 
- Updated some files related to the sign and update of the block to have that org in the desired channel

 

**Reviewed by**
@jagpreetsinghsasan 
@suvajit-sarkar 

 **Screenshots**
In this screenshot, we can see that the existing creator org (calv) and the new org (malv) are in the same consortium
![consortium](https://user-images.githubusercontent.com/76157062/110956125-983ec080-834a-11eb-81fd-e0df0943c6de.png)

In this screenshot, we can see that both orgs have one anchorpeer each, the existing one and the new one created.
![anchor_added_to_channel](https://user-images.githubusercontent.com/76157062/110956310-c91ef580-834a-11eb-9c90-9b31135e6df2.png)


**Linked issue**
#1297
