### PR TITLE
[ Fabric ] Changed affiliation to fully save the certificates for user1

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto_script/templates/organisation_script.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto_script/templates/organisation_script.tpl
@@ -6,7 +6,7 @@ CURRENT_DIR=${PWD}
 FULLY_QUALIFIED_ORG_NAME="{{ component_ns }}"
 ALTERNATIVE_ORG_NAMES=("{{ component_ns }}.svc.cluster.local" "{{ component_name }}.net" "{{ component_ns }}.{{ item.external_url_suffix }}")
 ORG_NAME="{{ component_name }}"
-AFFILIATION="{{ component_subject.split(',')| select('match','OU=*') | list | first | regex_replace('OU=','') }}"
+AFFILIATION="{{ component_name }}"
 SUBJECT="C={{ component_country }},ST={{ component_state }},L={{ component_location }},O={{ component_name }}"
 SUBJECT_PEER="{{ component_subject }}"
 CA="{{ ca_url }}"


### PR DESCRIPTION
Changelog

Fixed line in platforms/hyperledger-fabric/configuration/roles/create/crypto_script/templates/organisation_script.tpl for the affiliation, which was getting the name "carrier" or "manufacturer" from subject instead of the name of the organization.

Reviewed by
@jagpreetsinghsasan 
@suvajit-sarkar 

Linked issue
#1306 

Now, user1 has every certificate, as expected:

![image](https://user-images.githubusercontent.com/76157062/111960295-da58c680-8aef-11eb-8111-cca80d1057d4.png)

