### PR TITLE
[fabric] Updated condition for not creating a channel when adding a new peer t…

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/create/channels_join/tasks/nested_channel_join.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/channels_join/tasks/nested_channel_join.yaml
@@ -10,7 +10,9 @@
     namespace: "{{ participant.name | lower}}-net"
     component_name: "createchannel-{{ channel_name }}"
     kubernetes: "{{ org.k8s }}"
-  when: participant.type == 'creator'
+  when:
+    - participant.type == 'creator'
+    - participant.org_status is not defined or participant.org_status == 'new'
 
 # Create the join channel value file for each participating peer
 - name: "join channel {{ channel_name }}"


### PR DESCRIPTION
…o an existing creator org

Signed-off-by: alvaropicazo <alvaro.picazo.haase@accenture.com>

**Changelog**
- Fix condition when adding a new peer to an existing creator org, for not running the create channel task as it is not wanted in that case. Now it will only be run if the participant.type is a creator AND the org_status is not defined or it is new.