### PR TITLE
update to java14

### DIFF
--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
         curl \
         unzip \
         build-essential \
-        openjdk-14-jdk \
+        openjdk-8-jdk \
 	    openssh-client \
         gcc \
         git \

--- a/docs/source/developer/baf_minikube_setup.md
+++ b/docs/source/developer/baf_minikube_setup.md
@@ -172,6 +172,8 @@ kubectl get pods --all-namespaces -w
 
 **NOTE:** If you need public address for nodes in your `network.yaml` file, you can use the output of `minikube ip`.
 
+**NOTE**. baf-build image is using jdk14 but Corda and Corda Enterprise requires jdk8. In this case, you can use the prebuild image tag *jdk8*  hyperledgerlabs/baf-build:jdk8
+
 ## Troubleshooting
 
 **`Failed to establish a new connection: [Errno 111] Connection refused`**

--- a/docs/source/developer/docker-build.md
+++ b/docs/source/developer/docker-build.md
@@ -40,6 +40,8 @@ Use the below command to run the container and the provisioning scripts, the com
 ```shell
 docker run -it -v $(pwd):/home/blockchain-automation-framework/ hyperledgerlabs/baf-build
 ```
+**NOTE**. baf-build image is using jdk14 but Corda and Corda Enterprise requires jdk8. In this case, you can build the baf-build image using Dockerfile.jdk8 or use the prebuild image tag *jdk8*  hyperledgerlabs/baf-build:jdk8
+
 Before running the above command add a build folder in the root directory of the repository, this build folder should have the following files:
 
 1) K8s config file as config  


### PR DESCRIPTION
Signed-off-by: Jose Pazos <pppazos@gmail.com>

**Changelog**
- Add Dockerfile.jdk8 for Corda and Corda Enterprise
- Updated Dockerfile to use ubuntu 20.04 and jdk14

 

**Reviewed by**
@pppazos

 

**Linked issue**
#1023 
