### PR TITLE
Update the openshift version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:20.04
 # Create working directory
 WORKDIR /home/
 ENV PYTHON_VERSION='3.6.13'
-ENV OPENSHIFT_VERSION='0.10.1'
+ENV OPENSHIFT_VERSION='0.11.0'
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
**Changelog**
- Fix
The openshift versions before 0.11.0 do not handle
K8s config from Azure clusters.
Ref: https://github.com/kubernetes-client/python-base/pull/141/files

**Reviewed by**
@sownak 

**Linked issue**
#1466
