### PR TITLE
[corda-ent] certificates for ambassador

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN apt-get update && apt-get install -y \
     pip3 install jmespath && \
     pip3 install openshift==${OPENSHIFT_VERSION} && \
     apt-get clean && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python3-venv
 
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN mkdir /etc/ansible/

--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -7,7 +7,7 @@ FROM ubuntu:20.04
 # Create working directory
 WORKDIR /home/
 ENV PYTHON_VERSION='3.6.13'
-ENV OPENSHIFT_VERSION='0.10.1'
+ENV OPENSHIFT_VERSION='0.11.0'
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -39,7 +39,9 @@ RUN apt-get update && apt-get install -y \
     pip3 install jmespath && \
     pip3 install openshift==${OPENSHIFT_VERSION} && \
     apt-get clean && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python3-venv
 
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN mkdir /etc/ansible/

--- a/platforms/r3-corda-ent/charts/idman/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/idman/templates/service.yaml
@@ -20,7 +20,7 @@ metadata:
       name: {{ .Values.nodeName }}_mapping_tlscontext
       hosts:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
-      secret: {{ .Values.nodeName }}-ambassador-certs.default
+      secret: {{ .Values.nodeName }}-ambassador-certs.{{ .Values.metadata.namespace }}
       secret_namespacing: true
   {{ end }}
   labels:

--- a/platforms/r3-corda-ent/charts/nmap/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/nmap/templates/deployment.yaml
@@ -309,7 +309,7 @@ spec:
             sshdPort = {{ .Values.service.shell.sshdPort }}
             user = "{{ .Values.service.shell.user }}"
             password = "{{ .Values.service.shell.password }}"
-          }' >> etc/nmap.conf
+          }' > etc/nmap.conf
 
           export NETWORKMAP_SSL=$(cat {{ .Values.config.volume.baseDir }}/DATA/ssl/networkmapssl)
           sed -i -e "s*NETWORKMAP_SSL*${NETWORKMAP_SSL}*g" etc/nmap.conf

--- a/platforms/r3-corda-ent/charts/nmap/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/nmap/templates/service.yaml
@@ -21,7 +21,7 @@ metadata:
       name: {{ .Values.nodeName }}_mapping_tlscontext
       hosts:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
-      secret: {{ .Values.nodeName }}-ambassador-certs.default
+      secret: {{ .Values.nodeName }}-ambassador-certs.{{ .Values.metadata.namespace }}
       secret_namespacing: true
   {{ end }}
   labels:

--- a/platforms/r3-corda-ent/charts/node-initial-registration/templates/job.yaml
+++ b/platforms/r3-corda-ent/charts/node-initial-registration/templates/job.yaml
@@ -250,8 +250,10 @@ spec:
             export KEYSTORE_PASSWORD=$(cat DATA/credentials/keystorepass)
             sed -i -e "s*KEYSTORE_PASSWORD*${KEYSTORE_PASSWORD}*g" etc/node.conf
   
-            yes | keytool -importcert -file DATA/tlscerts/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-            yes | keytool -importcert -file DATA/tlscerts/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
+            SSL_TRUSTSTORE_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)
+            CORDA_SSL_TRUSTSTORE=DATA/trust-stores/corda-ssl-custom-trust-store.jks
+            yes | keytool -importcert -file DATA/tlscerts/networkmap.crt -storepass $SSL_TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.networkMapDomain }} -keystore $CORDA_SSL_TRUSTSTORE
+            yes | keytool -importcert -file DATA/tlscerts/idman.crt -storepass $SSL_TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.idmanDomain }} -keystore $CORDA_SSL_TRUSTSTORE
             
             /bin/sh
                       
@@ -280,6 +282,9 @@ spec:
             # Check for Idman and networkmap service links are up
             server=$(echo {{ .Values.networkServices.doormanURL }} | sed 's/.*\/\/\(.*\):\(.*\)/\1/' )
             port=$(echo {{ .Values.networkServices.doormanURL }} | sed 's/.*\/\/\(.*\):\(.*\)/\2/' )
+            #handle when no port is provided
+            [[ ${server} = ${port} ]] && port=443
+            server=$(echo $server|sed 's/.*\/\/\(.*\)/\1/')
             printf "IdMan server:%s" "${server}"
             printf "  IdMan port:%s" "${port}"
             timeout 10m bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' ${server} ${port}
@@ -292,7 +297,8 @@ spec:
                     echo "Node: running initial registration ..."
                     echo
                     pwd
-                    java -jar {{ .Values.nodeConf.jarPath }}/corda.jar \
+                    java -Djavax.net.ssl.trustStore=${CORDA_SSL_TRUSTSTORE} \
+                      -jar {{ .Values.nodeConf.jarPath }}/corda.jar \
                       initial-registration \
                     --config-file={{ .Values.nodeConf.configPath }}/node.conf \
                     --log-to-console \

--- a/platforms/r3-corda-ent/charts/node/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/node/templates/deployment.yaml
@@ -393,7 +393,6 @@ spec:
               echo
               sleep ${HOW_LONG}
           fi
-          sleep 1200
           echo "DONE"
         volumeMounts:
         - name: node-volume

--- a/platforms/r3-corda-ent/charts/node/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/node/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             echo "Getting secrets from Vault Server"
             KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
             VAULT_TOKEN=$(curl -sS --request POST ${VAULT_ADDR}/v1/auth/${KUBERNETES_AUTH_PATH}/login -H "Content-Type: application/json" -d '{"role":"'"${VAULT_APP_ROLE}"'","jwt":"'"${KUBE_SA_TOKEN}"'"}' | jq -r 'if .errors then . else .auth.client_token end')
-            
+
             validateVaultResponse 'vault login token' "${VAULT_TOKEN}"
             echo "logged into vault"
             COUNTER=1
@@ -86,7 +86,7 @@ spec:
                 else
                   validateVaultResponse "${CERTS_SECRET_PREFIX}/certs/truststore" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
                   break
-                fi 
+                fi
                 COUNTER=`expr "$COUNTER" + 1`
             done
 
@@ -348,7 +348,7 @@ spec:
           {{- if eq .Values.dataSourceProperties.dataSource.dataSourceClassName "oracle.jdbc.pool.OracleDataSource" }}
               schema = xe
           {{- end}}
-          }' >> ${BASE_DIR}/node.conf
+          }' > ${BASE_DIR}/node.conf
 
           export TRUSTSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/credentials/truststorepass)
           sed -i -e "s*TRUSTSTORE_PASSWORD*${TRUSTSTORE_PASSWORD}*g" ${BASE_DIR}/node.conf
@@ -357,10 +357,10 @@ spec:
 
           # to clean network-parameters on every restart
           rm -rf ${BASE_DIR}/network-parameters
-          yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-          yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-          yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/node.crt -storepass changeit -alias {{ .Values.nodeName }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-          
+          yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/networkmap.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.networkMapDomain }} -keystore ${BASE_DIR}/certificates/truststore.jks
+          yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/idman.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.networkServices.idmanDomain }} -keystore ${BASE_DIR}/certificates/truststore.jks
+          yes | keytool -importcert -file ${BASE_DIR}/certificates/tlscerts/node.crt -storepass $TRUSTSTORE_PASSWORD -alias {{ .Values.nodeName }} -keystore ${BASE_DIR}/certificates/truststore.jks
+
           /bin/sh
           
           KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/credentials/keystorepass)
@@ -370,7 +370,12 @@ spec:
               echo "Starting Node node ..."
               echo
               # command to run corda jar, we are setting javax.net.ssl.keyStore as ${BASE_DIR}/certificates/sslkeystore.jks since keystore gets reset when using h2 ssl 
-              java -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} -jar {{ .Values.nodeConf.jarPath }}/corda.jar -f ${BASE_DIR}/node.conf --base-directory ${BASE_DIR}
+              java -Djavax.net.ssl.trustStore=${BASE_DIR}/certificates/truststore.jks \
+                   -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks \
+                   -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
+                   -jar {{ .Values.nodeConf.jarPath }}/corda.jar \
+                   -f ${BASE_DIR}/node.conf --base-directory ${BASE_DIR} \
+                   --log-to-console
               EXIT_CODE=${?}
           else
               echo "Missing node jar file in {{ .Values.nodeConf.jarPath }} folder:"
@@ -388,6 +393,7 @@ spec:
               echo
               sleep ${HOW_LONG}
           fi
+          sleep 1200
           echo "DONE"
         volumeMounts:
         - name: node-volume

--- a/platforms/r3-corda-ent/charts/node/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/node/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
       name: {{ .Values.nodeName }}_context
       hosts:
       - {{ .Values.nodeName }}.{{ .Values.nodeConf.ambassador.external_url_suffix }}
-      secret: {{ .Values.nodeName }}-ambassador-certs.default
+      secret: {{ .Values.nodeName }}-ambassador-certs.{{ .Values.metadata.namespace }}
       secret_namespacing: true
       ---
       apiVersion: ambassador/v2

--- a/platforms/r3-corda-ent/charts/notary-initial-registration/templates/job.yaml
+++ b/platforms/r3-corda-ent/charts/notary-initial-registration/templates/job.yaml
@@ -87,6 +87,9 @@ spec:
                       validateVaultResponse "${CERTS_SECRET_PREFIX}/root/certs" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
                       network_root_truststore=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["network-root-truststore.jks"]')
                       echo "${network_root_truststore}" | base64 -d > ${MOUNT_PATH}/trust-stores/network-root-truststore.jks
+                      # ssl trust store
+                      corda_ssl_trust_store=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-trust-store.jks"]')
+                      echo "${corda_ssl_trust_store}" | base64 -d > ${MOUNT_PATH}/trust-stores/corda-ssl-trust-store.jks
                       echo "Successfully got network truststore certifcates"
                       break
                     fi 
@@ -220,18 +223,17 @@ spec:
                         ALL
                     ]
                 }
-            ]' >> etc/notary.conf
+            ]' > etc/notary.conf
             export TRUSTSTORE_PASSWORD=$(cat {{ $.Values.nodeConf.volume.baseDir }}/DATA/truststore/ts)
             sed -i -e "s*TRUSTSTORE_PASSWORD*${TRUSTSTORE_PASSWORD}*g" etc/notary.conf
             export KEYSTORE_PASSWORD=$(cat {{ $.Values.nodeConf.volume.baseDir }}/DATA/keystore/ks)
             sed -i -e "s*KEYSTORE_PASSWORD*${KEYSTORE_PASSWORD}*g" etc/notary.conf
             rm -r ${BASE_DIR}/certificates/done.txt
-            yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-            yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-            
-            
-            
+            #yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
+            #yes | keytool -importcert -file {{ $.Values.nodeConf.volume.baseDir }}/DATA/tlscerts/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
+
             /bin/sh
+            CORDA_SSL_TRUSTSTORE={{ $.Values.nodeConf.volume.baseDir }}/DATA/trust-stores/corda-ssl-trust-store.jks
             NETWORK_ROOT_TRUSTSTORE={{ $.Values.nodeConf.volume.baseDir }}/DATA/trust-stores/network-root-truststore.jks
             NETWORK_ROOT_TRUSTSTORE_PASSWORD=$(cat {{ $.Values.nodeConf.volume.baseDir }}/DATA/truststore/rootcats)
 
@@ -243,8 +245,8 @@ spec:
                     echo "Notary: running initial registration ..."
                     echo
                     pwd
-                    java -Dcapsule.jvm.args='-Xmx{{ .Values.nodeConf.cordaJar.memorySize }}{{ .Values.nodeConf.cordaJar.unit }}' -jar {{ .Values.nodeConf.jarPath }}/corda.jar \
-                      initial-registration \
+                    java -Dcapsule.jvm.args='-Xmx{{ .Values.nodeConf.cordaJar.memorySize }}{{ .Values.nodeConf.cordaJar.unit }}' -Djavax.net.ssl.trustStore=${CORDA_SSL_TRUSTSTORE} \
+                    -jar {{ .Values.nodeConf.jarPath }}/corda.jar initial-registration \
                     --config-file={{ .Values.nodeConf.configPath }}/notary.conf \
                     --log-to-console \
                     --network-root-truststore ${NETWORK_ROOT_TRUSTSTORE}  \

--- a/platforms/r3-corda-ent/charts/notary/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/notary/templates/deployment.yaml
@@ -162,16 +162,13 @@ spec:
               TLS_TRUSTSTORE=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["truststore.jks"]')
               echo "${TLS_TRUSTSTORE}" | base64 -d > ${OUTPUT_PATH}/truststore.jks
 
-              LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ .Values.networkServices.idmanName }}/tlscerts | jq -r 'if .errors then . else . end')
-              validateVaultResponse "${CERTS_SECRET_PREFIX}/{{ .Values.networkServices.idmanName }}/tlscerts" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
-              IDMAN_CERT=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tlscacerts"]')
-              echo "${IDMAN_CERT}" | base64 -d > ${OUTPUT_PATH}/idman.crt
+              # get ca ssl-truststore.jks from vault
+              LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/root/certs | jq -r 'if .errors then . else . end')
+              validateVaultResponse "${CERTS_SECRET_PREFIX}/root/certs" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
+              TLS_TRUSTSTORE=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["corda-ssl-trust-store.jks"]')
+              echo "${TLS_TRUSTSTORE}" | base64 -d > ${OUTPUT_PATH}/corda-ssl-trust-store.jks 
 
-              LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/{{ .Values.networkServices.networkmapName }}/tlscerts | jq -r 'if .errors then . else . end')
-              validateVaultResponse "${CERTS_SECRET_PREFIX}/{{ .Values.networkServices.networkmapName }}/tlscerts" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
-              NETWORKMAP_CERT=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["tlscacerts"]')
-              echo "${NETWORKMAP_CERT}" | base64 -d > ${OUTPUT_PATH}/networkmap.crt             
-              echo "Done fetching all certificates from vault"
+               echo "Done fetching all certificates from vault"
 
               # Fetching keystore credentials from vault
               LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/credentials/keystore | jq -r 'if .errors then . else . end')
@@ -183,7 +180,13 @@ spec:
               LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/credentials/truststore | jq -r 'if .errors then . else . end')
               validateVaultResponse "${CERTS_SECRET_PREFIX}/credentials/truststore" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
               KEYSTORE_PASSWORD=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["trustStorePassword"]')
-              echo "${KEYSTORE_PASSWORD}"> ${OUTPUT_PATH}/tspass
+              echo "${KEYSTORE_PASSWORD}"> ${OUTPUT_PATH}/tspass    
+
+              # Fetching ssl truststore credentials from vault
+              LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/credentials/truststore | jq -r 'if .errors then . else . end')
+              validateVaultResponse "${CERTS_SECRET_PREFIX}/credentials/truststore" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
+              KEYSTORE_PASSWORD=$(echo ${LOOKUP_SECRET_RESPONSE} | jq -r '.data["ssl"]')
+              echo "${KEYSTORE_PASSWORD}"> ${OUTPUT_PATH}/sslpass 
               echo "Fetched credentials from vault"
         volumeMounts:
         - name: notary-certificates
@@ -325,9 +328,10 @@ spec:
 
           sshd {
               port={{ .Values.service.sshdPort }}
-          }' >> ${BASE_DIR}/etc/notary.conf
+          }' > ${BASE_DIR}/etc/notary.conf
 
           export TRUSTSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/tspass)
+          export SSLTRUSTSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/sslpass)
           sed -i -e "s*TRUSTSTORE_PASSWORD*${TRUSTSTORE_PASSWORD}*g" ${BASE_DIR}/etc/notary.conf
           export KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/kspass)
           sed -i -e "s*KEYSTORE_PASSWORD*${KEYSTORE_PASSWORD}*g" ${BASE_DIR}/etc/notary.conf
@@ -337,9 +341,8 @@ spec:
           rm -rf ${BASE_DIR}/network-parameters
 
           # add idman and networkmap certificates to java keystore
-          yes | keytool -importcert -file ${BASE_DIR}/certificates/networkmap.crt -storepass changeit -alias {{ .Values.networkServices.networkMapDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-          yes | keytool -importcert -file ${BASE_DIR}/certificates/idman.crt -storepass changeit -alias {{ .Values.networkServices.idmanDomain }} -keystore /usr/lib/jvm/java-1.8-zulu8/jre/lib/security/cacerts
-
+          keytool -importkeystore -srckeystore ${BASE_DIR}/certificates/corda-ssl-trust-store.jks -srcstorepass $SSLTRUSTSTORE_PASSWORD -destkeystore ${BASE_DIR}/certificates/truststore.jks -deststorepass $TRUSTSTORE_PASSWORD -srcalias cordasslrootca -destalias cordasslrootca
+          
           /bin/sh
           KEYSTORE_PASSWORD=$(cat ${BASE_DIR}/certificates/kspass)
           if [ -f {{ .Values.nodeConf.jarPath }}/corda.jar ]
@@ -348,7 +351,7 @@ spec:
               echo "CENM: starting Notary node ..."
               echo
               # command to run corda jar, we are setting javax.net.ssl.keyStore as ${BASE_DIR}/certificates/sslkeystore.jks since keystore gets reset when using h2 ssl 
-              java -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} -jar {{ .Values.nodeConf.jarPath }}/corda.jar -f ${BASE_DIR}/etc/notary.conf --base-directory=${BASE_DIR} 
+              java -Djavax.net.ssl.trustStore=${BASE_DIR}/certificates/truststore.jks -Djavax.net.ssl.trustStorePassword=$TRUSTSTORE_PASSWORD -Djavax.net.ssl.keyStore=${BASE_DIR}/certificates/sslkeystore.jks -Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} -jar {{ .Values.nodeConf.jarPath }}/corda.jar -f ${BASE_DIR}/etc/notary.conf --base-directory=${BASE_DIR} -v --logging-level=DEBUG
               EXIT_CODE=${?}
           else
               echo "Missing notary jar file in {{ .Values.nodeConf.jarPath }} folder:"

--- a/platforms/r3-corda-ent/charts/notary/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/notary/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
       name: {{ .Values.nodeName }}_context
       hosts:
       - {{ .Values.nodeName }}.{{ .Values.nodeConf.ambassador.external_url_suffix }}
-      secret: {{ .Values.nodeName }}-ambassador-certs.default
+      secret: {{ .Values.nodeName }}-ambassador-certs.{{ .Values.metadata.namespace }}
       secret_namespacing: true
       ---
       apiVersion: ambassador/v2

--- a/platforms/r3-corda-ent/configuration/roles/create/certificates/cenm/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/certificates/cenm/tasks/main.yaml
@@ -62,11 +62,35 @@
     domain_name: "{{ service_name }}.{{ org.external_url_suffix }}"
   when: not openssl_conf_check.stat.exists
 
+# Check if tls ca file exists
+- name: Check if tls ca file exists
+  stat:
+    path: "./build/ambassador/corda-ssl-root-ca.key"
+  register: corda_ssl_ca_check
+
+# download from vault tls ca and convert from jks to p12
+- name: Get Corda SSL root ca
+  shell: |
+    echo $TRUSTSTORE_PASS
+    vault read -field=corda-ssl-root-keys.jks {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/root/certs |base64 -d > ./build/ambassador/corda-ssl-root-keys.jks
+    yes|keytool -importkeystore -srcstorepass $TRUSTSTORE_PASS -srckeystore ./build/ambassador/corda-ssl-root-keys.jks  -deststorepass $TRUSTSTORE_PASS -destkeystore ./build/ambassador/corda-ssl-root-keys.p12 -deststoretype PKCS12
+    openssl pkcs12 -in ./build/ambassador/corda-ssl-root-keys.p12 -passin pass:$TRUSTSTORE_PASS -nokeys -out ./build/ambassador/corda-ssl-root-ca.crt
+    openssl pkcs12 -in ./build/ambassador/corda-ssl-root-keys.p12 -passin pass:$TRUSTSTORE_PASS -nocerts -nodes -out ./build/ambassador/corda-ssl-root-ca.key 
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+    TRUSTSTORE_PASS: "{{ org.credentials.truststore.ssl }}"
+  when: not corda_ssl_ca_check.stat.exists
+
 # Create ambassador certificates
 - name: Create Ambassador certificates
   shell: |
-    cd {{ tlscert_path }}
-    openssl req -x509 -out ambassador.pem -keyout ambassador.key -newkey rsa:2048 -nodes -sha256 -subj "/CN={{ domain_name }}" -extensions EXT -config openssl.conf
+    # generate new key
+    openssl genrsa -out {{ tlscert_path }}/ambassador.key 2048
+    # create request
+    openssl req -new -key {{ tlscert_path }}/ambassador.key -out {{ tlscert_path }}/ambassador.csr -config {{ tlscert_path }}/openssl.conf -newkey rsa:2048 -nodes -sha256 -subj "/CN={{ domain_name }}" -extensions EXT
+    # sign with CA key
+    openssl x509 -req -in {{ tlscert_path }}/ambassador.csr -CA ./build/ambassador/corda-ssl-root-ca.crt -CAkey ./build/ambassador/corda-ssl-root-ca.key -CAcreateserial -outform PEM -out {{ tlscert_path }}/ambassador.pem -days 730 -extensions EXT -extfile {{ tlscert_path }}/openssl.conf 
   vars:
     domain_name: "{{ service_name }}.{{ org.external_url_suffix }}"
   when: ambassador_tls_certs.failed == True
@@ -80,11 +104,11 @@
     VAULT_TOKEN: "{{ org.vault.root_token }}"
   when: ambassador_tls_certs.failed == True
 
-# Check if the ambassador secret is created in the default namespace
+# Check if the ambassador secret is created in the org namespace
 - name: Check Ambassador cred exists
   k8s_info:
     kind: Secret
-    namespace: default
+    namespace: "{{ namespace }}"
     name: "{{ service_name }}-ambassador-certs"
     kubeconfig: "{{ org.k8s.config_file }}"
     context: "{{ org.k8s.context }}"
@@ -93,7 +117,7 @@
 # Create the ambassador secret if it doesn't exist
 - name: Create the Ambassador credentials
   shell: |
-    KUBECONFIG={{ org.k8s.config_file }} kubectl create secret tls {{ service_name }}-ambassador-certs --cert="{{ tlscert_path }}/ambassador.pem" --key="{{ tlscert_path }}/ambassador.key" -n default
+    KUBECONFIG={{ org.k8s.config_file }} kubectl create secret tls {{ service_name }}-ambassador-certs --cert="{{ tlscert_path }}/ambassador.pem" --key="{{ tlscert_path }}/ambassador.key" -n {{ namespace }}
   when: get_ambassador_secret.resources|length == 0
 
 # Copy generated crt to build location

--- a/platforms/r3-corda-ent/configuration/roles/create/certificates/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/create/certificates/node/tasks/main.yaml
@@ -79,7 +79,7 @@
 - name: Check if Ambassador creds exists
   k8s_info:
     kind: Secret
-    namespace: default
+    namespace: "{{ namespace }}"
     name: "{{ node_name }}-ambassador-certs"
     kubeconfig: "{{ k8s.config_file }}"
     context: "{{ k8s.context }}"
@@ -88,5 +88,5 @@
 # Create the ambassador secret if it doesn't exist
 - name: Create the Ambassador credentials
   shell: |
-    KUBECONFIG={{ k8s.config_file }} kubectl create secret tls {{ node_name }}-ambassador-certs --cert="./build/ambassador/{{ node_name }}/ambassador.pem" --key="./build/ambassador/{{ node_name }}/ambassador.key" -n default
+    KUBECONFIG={{ k8s.config_file }} kubectl create secret tls {{ node_name }}-ambassador-certs --cert="./build/ambassador/{{ node_name }}/ambassador.pem" --key="./build/ambassador/{{ node_name }}/ambassador.key" -n {{ namespace }}
   when: get_ambassador_secret.resources|length == 0

--- a/platforms/r3-corda-ent/configuration/roles/setup/credentials/tasks/node_tasks_nested.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/credentials/tasks/node_tasks_nested.yaml
@@ -20,15 +20,6 @@
   when: org.firewall.enabled
 
 # Write the networkroot truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
-- name: Write the networkroot truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
-  shell: |
-    vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/credentials root={{ network | json_query('network_services[?type==`networkmap`].truststore_pass') | first }} truststore={{ peer.credentials.truststore }} keystore={{ peer.credentials.keystore }} firewallca={{ org.firewall.credentials.firewallca }} float={{ org.firewall.credentials.float }} bridge={{ org.firewall.credentials.bridge }} {{ peer.name }}={{ peer.name }}P
-  environment:
-    VAULT_ADDR: "{{ org.vault.url }}"
-    VAULT_TOKEN: "{{ org.vault.root_token }}"
-  when: vault_credentials_node.failed == True
-
-# Write the networkroot truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
 - name: Write the truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
   shell: |
     vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/credentials truststore={{ peer.credentials.truststore }} keystore={{ peer.credentials.keystore }} firewallca={{ org.firewall.credentials.firewallca }} float={{ org.firewall.credentials.float }} bridge={{ org.firewall.credentials.bridge }} {{ peer.name }}={{ peer.name }}P
@@ -36,6 +27,15 @@
     VAULT_ADDR: "{{ org.services.float.vault.url }}"
     VAULT_TOKEN: "{{ org.services.float.vault.root_token }}"
   when: org.firewall.enabled and float_vault_credentials.failed == True
+
+# Write the networkroot truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
+- name: Write the networkroot truststore, node truststore, node keystore, firewallca, float and bridge passwords to the vault
+  shell: |
+    vault write {{ org.vault.secret_path | default('secret') }}/{{ org.name | lower }}/{{ peer.name | lower }}/credentials root={{ network | json_query('network_services[?type==`networkmap`].truststore_pass') | first }} truststore={{ peer.credentials.truststore }} keystore={{ peer.credentials.keystore }} firewallca={{ org.firewall.credentials.firewallca }} float={{ org.firewall.credentials.float }} bridge={{ org.firewall.credentials.bridge }} {{ peer.name }}={{ peer.name }}P
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+  when: vault_credentials_node.failed == True
 
 - name: "Write cordapps credentials to vault"
   shell: |

--- a/platforms/r3-corda-ent/configuration/roles/setup/idman/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/idman/tasks/main.yaml
@@ -20,6 +20,7 @@
     tlscert_path: "./build/ambassador/{{ org.services.idman.name }}"
     dest_path: "{{ network | json_query('network_services[?type==`idman`].certificate') | first }}"
     service_name: "{{ org.services.idman.name }}"
+    namespace: "{{ component_ns }}"
 
 # This task will loop over the network.yaml to fetch the cenm details
 - name: Create value file for idman

--- a/platforms/r3-corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/nmap/tasks/main.yaml
@@ -30,6 +30,7 @@
   vars:
     tlscert_path: "./build/ambassador/{{ org.services.networkmap.name }}"
     service_name: "{{ org.services.networkmap.name }}"
+    namespace: "{{ component_ns }}"
     dest_path: "{{ network | json_query('network_services[?type==`networkmap`].certificate') | first }}"
 
 # Get the network-root-truststore and save locally

--- a/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/node/tasks/main.yaml
@@ -92,6 +92,7 @@
     k8s: "{{ org.services.float.k8s }}"
     vault: "{{ org.services.float.vault }}"
     node_name: "{{ org.name | lower }}"
+    namespace: "{{ component_ns }}"
     domain_name: "{{ org.services.float.name }}.{{ node_name }}.{{ org.services.float.external_url_suffix }}"
   when: org.firewall.enabled
 
@@ -103,6 +104,7 @@
     k8s: "{{ org.k8s }}"
     vault: "{{ org.vault }}"
     node_name: "{{ peer.name | lower }}"
+    namespace: "{{ component_ns }}"
     domain_name: "{{ node_name }}.{{ org.external_url_suffix }}"
   loop: "{{ org.services.peers }}"
   loop_control:

--- a/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/notary/tasks/main.yaml
@@ -21,6 +21,7 @@
   vars:
     tlscert_path: "./build/ambassador/{{ notary.name }}"
     service_name: "{{ notary.name }}"
+    namespace: "{{ component_ns }}"
     dest_path: "./build/ambassador/{{ notary.name }}/notary.crt"
   loop: "{{ org.services.notaries }}"
   loop_control:


### PR DESCRIPTION
**Changelog**
- in cenm (idman, network, notaries) trust tls root ca in cenm organization
- in nodes (include idman and network crts in corda truststore)
- k8s tls secrets created in the org namespace


**Reviewed by**
@sownak 
@suvajit-sarkar 

 

**Linked issue**
#996 #1462 
