### PR TITLE
[shared] only TLS 1.2+ allowed

### DIFF
--- a/platforms/hyperledger-besu/charts/node_orion/templates/service.yaml
+++ b/platforms/hyperledger-besu/charts/node_orion/templates/service.yaml
@@ -35,6 +35,7 @@ metadata:
       - {{ .Values.proxy.external_url }}
       secret: {{ .Values.node.name }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
     {{- end }}
   creationTimestamp: null
   labels:

--- a/platforms/hyperledger-fabric/charts/ca/templates/service.yaml
+++ b/platforms/hyperledger-fabric/charts/ca/templates/service.yaml
@@ -41,6 +41,7 @@ metadata:
       hosts:
       - ca.{{ $.Values.metadata.namespace }}
       secret: ca-{{ $.Values.metadata.namespace }}-ambassador-certs
+      min_tls_version: v1.2
   {{ end }}
   labels:
     run: {{ $.Values.server.name }}

--- a/platforms/hyperledger-fabric/charts/orderernode/templates/service.yaml
+++ b/platforms/hyperledger-fabric/charts/orderernode/templates/service.yaml
@@ -21,6 +21,7 @@ metadata:
       - {{ $.Values.orderer.name }}.{{ $.Values.proxy.external_url_suffix }}
       secret: {{ $.Values.orderer.name }}-{{ $.Values.metadata.namespace }}-ambassador-certs
       alpn_protocols: h2
+      min_tls_version: v1.2
       ---
       apiVersion: ambassador/v2
       kind: Mapping

--- a/platforms/hyperledger-fabric/charts/peernode/templates/service.yaml
+++ b/platforms/hyperledger-fabric/charts/peernode/templates/service.yaml
@@ -27,6 +27,7 @@ metadata:
       - {{ $.Values.peer.name }}.{{ $.Values.metadata.namespace }}.{{ $.Values.proxy.external_url_suffix }}
       secret: {{ $.Values.peer.name }}-{{ $.Values.metadata.namespace }}-ambassador-certs
       alpn_protocols: h2
+      min_tls_version: v1.2
       ---
       apiVersion: ambassador/v2
       kind: Mapping

--- a/platforms/quorum/charts/node_tessera/templates/service.yaml
+++ b/platforms/quorum/charts/node_tessera/templates/service.yaml
@@ -35,6 +35,7 @@ metadata:
       - {{ .Values.proxy.external_url }}
       secret: {{ .Values.node.name }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
       {{- if eq $.Values.node.consensus "raft" }}
       ---
       apiVersion: ambassador/v2

--- a/platforms/r3-corda-ent/charts/idman/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/idman/templates/service.yaml
@@ -22,6 +22,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
   {{ end }}
   labels:
     run: {{ .Values.nodeName }}

--- a/platforms/r3-corda-ent/charts/nmap/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/nmap/templates/service.yaml
@@ -23,6 +23,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
   {{ end }}
   labels:
     run: {{ .Values.nodeName }}

--- a/platforms/r3-corda-ent/charts/node/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/node/templates/service.yaml
@@ -14,6 +14,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.nodeConf.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
       ---
       apiVersion: ambassador/v2
       kind: TCPMapping

--- a/platforms/r3-corda-ent/charts/notary/templates/service.yaml
+++ b/platforms/r3-corda-ent/charts/notary/templates/service.yaml
@@ -14,6 +14,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.nodeConf.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
       ---
       apiVersion: ambassador/v2
       kind: TCPMapping

--- a/platforms/r3-corda/charts/doorman-tls/templates/service.yaml
+++ b/platforms/r3-corda/charts/doorman-tls/templates/service.yaml
@@ -22,6 +22,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
   {{ end }}
   labels:
     run: {{ .Values.nodeName }}

--- a/platforms/r3-corda/charts/doorman/templates/service.yaml
+++ b/platforms/r3-corda/charts/doorman/templates/service.yaml
@@ -22,6 +22,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
   {{ end }}
   labels:
     run: {{ .Values.nodeName }}

--- a/platforms/r3-corda/charts/nms-tls/templates/service.yaml
+++ b/platforms/r3-corda/charts/nms-tls/templates/service.yaml
@@ -22,6 +22,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
   {{ end }}
   labels:
     run: {{ .Values.nodeName }}

--- a/platforms/r3-corda/charts/nms/templates/service.yaml
+++ b/platforms/r3-corda/charts/nms/templates/service.yaml
@@ -22,6 +22,7 @@ metadata:
       - {{ .Values.nodeName }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.nodeName }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
   {{ end }}
   labels:
     run: {{ .Values.nodeName }}

--- a/platforms/r3-corda/charts/node/templates/service.yaml
+++ b/platforms/r3-corda/charts/node/templates/service.yaml
@@ -13,6 +13,7 @@ metadata:
       - {{ .Values.ambassador.component_name }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.ambassador.component_name }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
       ---
       apiVersion: ambassador/v2
       kind: TCPMapping

--- a/platforms/r3-corda/charts/notary/templates/service.yaml
+++ b/platforms/r3-corda/charts/notary/templates/service.yaml
@@ -13,6 +13,7 @@ metadata:
       - {{ .Values.ambassador.component_name }}.{{ .Values.ambassador.external_url_suffix }}
       secret: {{ .Values.ambassador.component_name }}-ambassador-certs.default
       secret_namespacing: true
+      min_tls_version: v1.2
       ---
       apiVersion: ambassador/v2
       kind: TCPMapping

--- a/platforms/shared/charts/ambassador/templates/service.yaml
+++ b/platforms/shared/charts/ambassador/templates/service.yaml
@@ -29,7 +29,7 @@ metadata:
       name: ambassador_context
       hosts:
       - "*"
-      secret: fallback-self-signed-cert.default
+      secret: ambassador-default-tls.default
       secret_namespacing: true
       min_tls_version: v1.2
   {{- if .Values.ambassador.eip }}

--- a/platforms/shared/charts/ambassador/templates/service.yaml
+++ b/platforms/shared/charts/ambassador/templates/service.yaml
@@ -21,12 +21,18 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}  
-  {{- if .Values.ambassador.eip }}
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-    service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "{{ .Values.ambassador.eip }}"
     getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v2
+      kind: TLSContext
+      name: ambassador_context
+      hosts:
+      - "*"
+      secret: fallback-self-signed-cert.default
+      secret_namespacing: true
+      min_tls_version: v1.2
+  {{- if .Values.ambassador.eip }}
       ---
       apiVersion: ambassador/v2
       kind:  Module
@@ -34,12 +40,11 @@ metadata:
       config:
         use_proxy_proto: true
         use_remote_address: false
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp        
+    service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "{{ .Values.ambassador.eip }}"
   {{- end }}
   {{- if .Values.ambassador.grpc }}
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-    getambassador.io/config: |
       ---
       apiVersion: ambassador/v2
       kind:  Module
@@ -49,6 +54,8 @@ metadata:
         enable_grpc_web: true
         use_remote_address: false
         x_forwarded_proto_redirect: true
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp        
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/converge.yml
@@ -81,16 +81,6 @@
           port: "8443"
           image: quay.io/datawire/ambassador
           tag: "0.53.1"
-    - role: setup/haproxy-ingress
-      vars:
-        item:
-          cloud_provider: "aws"
-          k8s:
-            config_file: "/tmp/molecule/kind-default/kubeconfig"
-            context: "kind"
-        aws:
-          access_key: test
-          secret_key: test
   post_tasks:
     - name: Delete the temp secret file
       file:

--- a/platforms/shared/configuration/molecule/kubernetes-corda/verify.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-corda/verify.yml
@@ -41,18 +41,3 @@
   - name: Assert Ambassador has been installed and 3 pods running
     assert:
       that: ambassador_status.resources|length == 3
-  # Assert Haproxy is installed on Kubernetes
-  - name: Check Haproxy on Kubernetes clusters
-    k8s_info:
-      kind: Pod
-      namespace: "ingress-controller"
-      kubeconfig: "{{ kubeconfig_path }}"
-      context: "{{ kubecontext }}"
-      label_selectors:
-        - run = haproxy-ingress
-      field_selectors:
-        - status.phase=Running
-    register: haproxy_status
-  - name: Assert HAproxy has been installed
-    assert:
-      that: haproxy_status.resources|length == 1

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/converge.yml
@@ -15,11 +15,7 @@
         url: "index.docker.io/hyperledgerlabs"
       env:
         type: test
-        proxy: ambassador
-        ambassadorPorts:
-          portRange:
-            from: 15010 
-            to: 15020          
+        proxy: haproxy       
         retry_count: 20
         external_dns: disabled
   pre_tasks:
@@ -65,22 +61,6 @@
         git_host: "github.com"
         git_protocol: "ssh"
         helm_operator_version: "1.2.0"
-    - role: setup/ambassador
-      vars:
-        item:
-          cloud_provider: "aws"
-          k8s:
-            config_file: "/tmp/molecule/kind-default/kubeconfig"
-            context: "kind"
-        aws:
-          access_key: test
-          secret_key: test
-        ambassador:
-          version: "2.1.0"
-          targetPort: "443"
-          port: "8443"
-          image: quay.io/datawire/ambassador
-          tag: "0.53.1"
     - role: setup/haproxy-ingress
       vars:
         item:

--- a/platforms/shared/configuration/molecule/kubernetes-fabric/verify.yml
+++ b/platforms/shared/configuration/molecule/kubernetes-fabric/verify.yml
@@ -26,22 +26,6 @@
   - name: Assert Flux has been installed
     assert:
       that: flux_service.resources|length == 1
-  # Assert Ambassador is installed on Kubernetes
-  - name: Check Ambassador on Kubernetes clusters
-    k8s_info:
-      kind: Pod
-      namespace: default
-      kubeconfig: "{{ kubeconfig_path }}"
-      context: "{{ kubecontext }}"
-      label_selectors:
-        - app.kubernetes.io/name=ambassador
-      field_selectors:
-        - status.phase=Running
-    register: ambassador_status
-  - name: Assert Ambassador has been installed and 3 pods running
-    assert:
-      that: ambassador_status.resources|length == 3
-  # Assert Haproxy is installed on Kubernetes
   - name: Check Haproxy on Kubernetes clusters
     k8s_info:
       kind: Pod

--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -106,6 +106,8 @@
     kubeconfig: "{{ kubeconfig_path }}"
     context: "{{ kubecontext }}"
   register: default_ambassador_default_state    
+  tags:
+    - molecule-idempotence-notest  
 
 # Create and store selfsigned ambassador default certificate
 - name: Create Ambassador default certificate
@@ -114,6 +116,8 @@
     openssl req -x509 -out default_ambassador_tls.pem -keyout default_ambassador_tls.key -newkey rsa:2048 -nodes -sha256 -subj "/CN={{ item.external_url_suffix }}"
     KUBECONFIG={{ kubeconfig_path }} kubectl create secret tls ambassador-default-tls --cert="default_ambassador_tls.pem" --key="default_ambassador_tls.key" -n default
   when: default_ambassador_default_state.resources|length == 0
+  tags:
+    - molecule-idempotence-notest  
 
 - name: Install Ambassador with EIP for Indy
   shell: |

--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -126,17 +126,6 @@
     - ambassador
     - molecule-idempotence-notest
 
-# Disable TLS1.0 for the AWS Loadbalancer
-- name: Disable TLS1.0 for the AWS
-  shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl annotate service ambassador --overwrite "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy=ELBSecurityPolicy-TLS-1-2-2017-01"
-  when: 
-    - (network.type == 'indy' and allocation_ips.stdout is defined) or network.type != 'indy'
-    - item.cloud_provider == 'aws' or item.cloud_provider == 'aws-baremetal'
-  tags:
-    - ambassador
-    - molecule-idempotence-notest
-
 # Wait for Ambassador pods to start running
 - name: wait for pods to come up
   include_role:

--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -115,7 +115,10 @@
     mkdir -p ./build/ambassador && cd ./build/ambassador/
     openssl req -x509 -out default_ambassador_tls.pem -keyout default_ambassador_tls.key -newkey rsa:2048 -nodes -sha256 -subj "/CN={{ item.external_url_suffix }}"
     KUBECONFIG={{ kubeconfig_path }} kubectl create secret tls ambassador-default-tls --cert="default_ambassador_tls.pem" --key="default_ambassador_tls.key" -n default
-  when: default_ambassador_default_state.resources|length == 0
+  when: 
+    - default_ambassador_default_state.resources|length == 0
+    - network.env.external_dns is defined
+    - network.env.external_dns == 'enabled'
   tags:
     - molecule-idempotence-notest  
 

--- a/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/ambassador/tasks/main.yaml
@@ -97,6 +97,24 @@
   tags:
     - molecule-idempotence-notest
 
+# Check if default selfsigned ambassador tls is already created
+- name: Check Ambassador cred exists
+  k8s_info:
+    kind: Secret
+    namespace: default
+    name: "ambassador-default-tls"
+    kubeconfig: "{{ kubeconfig_path }}"
+    context: "{{ kubecontext }}"
+  register: default_ambassador_default_state    
+
+# Create and store selfsigned ambassador default certificate
+- name: Create Ambassador default certificate
+  shell: |
+    mkdir -p ./build/ambassador && cd ./build/ambassador/
+    openssl req -x509 -out default_ambassador_tls.pem -keyout default_ambassador_tls.key -newkey rsa:2048 -nodes -sha256 -subj "/CN={{ item.external_url_suffix }}"
+    KUBECONFIG={{ kubeconfig_path }} kubectl create secret tls ambassador-default-tls --cert="default_ambassador_tls.pem" --key="default_ambassador_tls.key" -n default
+  when: default_ambassador_default_state.resources|length == 0
+
 - name: Install Ambassador with EIP for Indy
   shell: |
     KUBECONFIG={{ kubeconfig_path }} helm upgrade --install --namespace default {{ ambassadorRange.stdout }} {{ ambassadorPortsIndy.stdout }} --set ambassador.eip='{{ allocation_ips.stdout }}' --set ambassador.targetPort={{ ambassador.targetPort }} --set ambassador.port={{ ambassador.port }} --set ambassador.tag={{ ambassador.tag }} --set ambassador.image={{ ambassador.image }} --set ambassador.loadBalancerSourceRanges={"{{ network.env.loadBalancerSourceRanges | default('0.0.0.0/0') }}"} ambassador {{ playbook_dir }}/../../../platforms/shared/charts/ambassador

--- a/platforms/shared/configuration/roles/setup/haproxy-ingress/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/setup/haproxy-ingress/tasks/main.yaml
@@ -30,15 +30,6 @@
     - molecule-idempotence-notest
   when: network.env.external_dns is defined and network.env.external_dns == 'enabled'
 
-# Disable TLS1.0 for the AWS Loadbalancer
-- name: Disable TLS1.0 for the AWS
-  shell: |
-    KUBECONFIG={{ kubeconfig_path }} kubectl annotate service haproxy-ingress -n ingress-controller --overwrite "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy=ELBSecurityPolicy-TLS-1-2-2017-01"
-  tags:
-    - haproxy
-    - molecule-idempotence-notest
-  when: item.cloud_provider == "aws"
-
 # Wait for HAProxy pods to start running
 - name: wait for pods to come up
   include_role:


### PR DESCRIPTION
Signed-off-by: pppazos <hgartti@gmail.com>

**Changelog**
- Add default TLSContext for ambassador
- Add min_tls_version: v1.2 in all Ambassador TLSContext objects
- Remove ELBSecurityPolicy-TLS-1-2-2017-01 annotation

 

**Reviewed by**
@sownak @suvajit-sarkar 

 

**Linked issue**
#1500 