### PR TITLE
[shared] removed need to have network.yaml in build folder for validation

### DIFF
--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -7,7 +7,7 @@
           "description": "Network description",
           "type": "object",
           "properties": {
-              "type": { "type": "string", "enum": ["fabric","corda", "corda-enterprise", "indy"],"description": "Network type"},
+              "type": { "type": "string", "enum": ["fabric","corda", "corda-enterprise", "indy", "quorum", "besu"],"description": "Network type"},
               "env": { "$ref":"#/definitions/shared_environment"},
               "docker": { "$ref":"#/definitions/shared_docker"}
           },

--- a/platforms/shared/configuration/network-schema-validator.yaml
+++ b/platforms/shared/configuration/network-schema-validator.yaml
@@ -11,6 +11,19 @@
       npm: 
         name: ajv-cli
         global: yes
+    - set_fact:
+        tempNetworkyaml: '{ "network": {{ network }} }'
+    - name: "Ensures build dir exists"
+      include_role:
+        name: "check/setup"
+      vars:
+        path: "./build"
+        check: "ensure_dir"
     - name: "run schema validator on network.yaml"
       shell: |
-        ajv validate -s ../../network-schema.json -d ../../../build/network.yaml         
+        echo  {{ tempNetworkyaml }} > ./build/temp.yaml
+        ajv validate -s ../../network-schema.json -d ./build/temp.yaml
+    - name: Remove the build directory and contents
+      file:
+        path: "./build"
+        state: absent


### PR DESCRIPTION
Signed-off-by: suvajit-sarkar <suvajit.sarkar@accenture.com>

**Changelog**
- Add quorum and besu in the validation network.type enum
- Fix need to have network.yaml in build folder for validation 

 

**Reviewed by**
@jagpreetsinghsasan 