### PR TITLE
[quorum] Quick fix to get permissions to extract go tarball in  /usr/local/ path

### DIFF
--- a/platforms/quorum/configuration/molecule/crypto-ibft/cleanup.yml
+++ b/platforms/quorum/configuration/molecule/crypto-ibft/cleanup.yml
@@ -10,6 +10,7 @@
     file:
       path: "./build"
       state: absent
+    become: yes  
 
   #This task deletes the temporarily created shared directory
   - name: Delete temp roles folder

--- a/platforms/quorum/configuration/roles/setup/golang/tasks/main.yaml
+++ b/platforms/quorum/configuration/roles/setup/golang/tasks/main.yaml
@@ -36,6 +36,7 @@
     src: "{{ tmp_directory.path }}/go{{ go.version }}.{{install_os}}-{{install_arch}}.tar.gz"
     dest: "{{ go_root_dir }}"
     copy: no
+  become: yes  
   when: not go_stat_result.stat.exists
   tags:
     molecule-idempotence-notest


### PR DESCRIPTION
Signed-off-by: alvaropicazo <alvaro.picazo.haase@accenture.com>

**Changelog**
- Fixed task to get the permissions for extracting the go tarball in /usr/local/ directory. 

 

**Reviewed by**
@sownak 
@suvajit-sarkar 

 

**Linked issue**
#1611 
