### PR TITLE
[fabric] Updated vault write command to support large file sizes

### DIFF
--- a/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
@@ -20,7 +20,7 @@
 
 - name: "Write genesis block to Vault"  
   shell: |
-    vault write {{ org.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ org.name }}-net {{ network.env.type }}GenesisBlock="$(cat {{build_path}}/channel-artifacts/genesis.block.base64)"
+    vault write {{ org.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ org.name }}-net {{ network.env.type }}GenesisBlock=@{{build_path}}/channel-artifacts/genesis.block.base64
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/shared/configuration/roles/check/helm_component/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/check/helm_component/tasks/main.yaml
@@ -9,7 +9,7 @@
     kubeconfig: "{{ kubernetes.config_file }}"
     context: "{{ kubernetes.context }}"
     label_selectors:
-      - app = {{ component_name }}
+      - "app = {{ component_name }}"
     field_selectors:
       - status.phase=Succeeded
   register: component_data


### PR DESCRIPTION
Signed-off-by: kaverikhaneja <kaveri.khaneja@accenture.com>

**Changelog**
- Updated vault write command to use a file instead of cat command while writing to the vault, to support large file sizes.

 

**Reviewed by**
@sownak @suvajit-sarkar @jagpreetsinghsasan 

 

**Linked issue**
#1642 
