### PR TITLE
[fabric] Access policies from the configmaps and deployment frabic to vaultv2

### DIFF
--- a/platforms/hyperledger-fabric/charts/ca_server/templates/job.yaml
+++ b/platforms/hyperledger-fabric/charts/ca_server/templates/job.yaml
@@ -79,10 +79,14 @@ spec:
               mkdir -p ${MOUNT_PATH}
 
               # Check if certificates already present in the vault
-              LOOKUP_SECRET_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${VAULT_SECRET_CRYPTO_PATH} | jq -r 'if .errors then . else . end')
+              LOOKUP_SECRET_RESPONSE=$(curl --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${VAULT_SECRET_CRYPTO_PATH} | jq -r 'if .errors then . else . end')
               if echo ${LOOKUP_SECRET_RESPONSE} | grep "errors"
               then
                 echo "Certficates absent in vault. Ignore error warning"
+                touch ${MOUNT_PATH}/absent_cacert.txt
+              elif echo ${LOOKUP_SECRET_RESPONSE} | grep "\"data\": null"
+              then
+                echo "Certficates absent in vault2. Ignore error warning"
                 touch ${MOUNT_PATH}/absent_cacert.txt
               else
                 validateVaultResponse "${VAULT_SECRET_CRYPTO_PATH}" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
@@ -96,6 +100,10 @@ spec:
               then
                 echo "Certficates absent in vault. Ignore error warning"
                 touch ${MOUNT_PATH}/absent_creds.txt
+              elif echo ${LOOKUP_SECRET_RESPONSE} | grep "\"data\": null"
+              then
+                echo "Certficates absent in vault2. Ignore error warning"
+                touch ${MOUNT_PATH}/absent_creds.txt
               else
                 validateVaultResponse "${VAULT_SECRET_CREDENTIALS_PATH}" "${LOOKUP_SECRET_RESPONSE}" "LOOKUPSECRETRESPONSE"
                 echo "Certificates present in vault"
@@ -103,7 +111,7 @@ spec:
               fi 
 
               echo "Done checking for certificates in vault"
-                         
+           
           volumeMounts:
           - name: certcheck
             mountPath: /certcheck
@@ -181,8 +189,11 @@ spec:
                 
                 echo "
                   {
-                    \"ca.${COMPONENT_NAME}-cert.pem\": \"${PEM_CERTIFICATE}\",
-                    \"${COMPONENT_NAME}-CA.key\": \"${KEY_CERTIFICATE}\"
+                    \"data\": 
+                      {
+                        \"ca.${COMPONENT_NAME}-cert.pem\": \"${PEM_CERTIFICATE}\",
+                        \"${COMPONENT_NAME}-CA.key\": \"${KEY_CERTIFICATE}\"
+                      }  
                   }" > payload.json
 
                 # This command copy the CA certificates to the Vault
@@ -212,7 +223,7 @@ spec:
                     -H "X-Vault-Token:  $ROOT_TOKEN" \
                     -H "Content-Type: application/json" \
                     -X POST \
-                    -d '{"user":"'"$NAME-adminpw"'"}' \
+                    -d '{ "data": {"user":"'"$NAME-adminpw"'"}}' \
                     ${VAULT_ADDR}/v1/${VAULT_SECRET_CREDENTIALS_PATH}
 
                   # Check CA server admin credentials
@@ -221,7 +232,8 @@ spec:
                   ${VAULT_ADDR}/v1/${VAULT_SECRET_CREDENTIALS_PATH});
 
                   validateVaultResponse ${response_status};
-              fi      
+              fi
+
           volumeMounts:
           - name: certcheck
             mountPath: /certcheck

--- a/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/configmap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policies-config-{{ .Values.metadata.component_type }}
+  namespace: {{ .Values.metadata.namespace }}
+  labels:
+    app.kubernetes.io/name: policies-config
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  policies-config-orderer.json.tmpl: |-
+    {"policy":"path \"{{ .Values.vault.secret_path }}/data/crypto/ordererOrganizations/{{ .Values.metadata.component_name }}/*\" {\n capabilities = [\"list\", \"read\"]\n}     \npath \"{{ .Values.vault.secret_path }}/*\" {\n capabilities = [\"list\"]\n}     \npath \"{{ .Values.vault.secret_path }}/data/crypto/peerOrganizations/*\" {\n capabilities = [\"deny\"]\n}     \npath \"{{ .Values.vault.secret_path }}/data/credentials/{{ .Values.metadata.component_name }}/*\" {\n capabilities = [\"list\", \"read\"]\n}"}
+  policies-config-peer.json.tmpl: |-
+    {"policy":"path \"{{ .Values.vault.secret_path }}/*\" {\n capabilities = [\"list\"]\n}     \npath \"{{ .Values.vault.secret_path }}/data/crypto/ordererOrganizations/*\" {\n capabilities = [\"deny\"]\n}     \npath \"{{ .Values.vault.secret_path }}/data/credentials/{{ .Values.metadata.component_name }}/*\" {\n capabilities = [\"list\", \"read\"]\n}     \npath \"{{ .Values.vault.secret_path }}/data/crypto/peerOrganizations\" {\n capabilities = [\"deny\"]\n}     \npath \"{{ .Values.vault.secret_path }}/data/crypto/peerOrganizations/*\" {\n capabilities = [\"deny\"]\n}     \npath \"{{ .Values.vault.secret_path }}/data/crypto/peerOrganizations/{{ .Values.metadata.component_name }}/*\" {\n capabilities = [\"list\", \"read\"]\n}"}

--- a/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/job.yaml
+++ b/platforms/hyperledger-fabric/charts/vault_kubernetes/templates/job.yaml
@@ -23,6 +23,22 @@ spec:
       imagePullSecrets:
         - name: {{ $.Values.vault.imagesecretname }}
       serviceAccountName: {{ $.Values.vault.serviceaccountname }}
+      volumes:
+      - name: policies
+        emptyDir:
+          medium: Memory
+      - name: policies-config-orderer
+        configMap:
+          name: policies-config-{{ .Values.metadata.component_type }}
+          items:
+            - key: policies-config-orderer.json.tmpl
+              path: policies-config-orderer.json.tmpl
+      - name: policies-config-peer
+        configMap:
+          name: policies-config-{{ .Values.metadata.component_type }}
+          items:
+            - key: policies-config-peer.json.tmpl
+              path: policies-config-peer.json.tmpl
       containers:
         - name:  "vault-kubernetes"
           image: {{ $.Values.metadata.images.alpineutils }}
@@ -52,6 +68,8 @@ spec:
             value: "{{ $.Values.checks.vault_auth_status_exits }}"
           - name: VAULT_POLICY
             value: "{{ $.Values.checks.vault_policy_not_exits }}"
+          - name: POLICIES_PATH
+            value: "/policies"
           - name: ROOT_TOKEN
             valueFrom:
               secretKeyRef:
@@ -115,37 +133,35 @@ spec:
               fi;
 
               if [ $VAULT_POLICY == 'true' ]; then
+              
+                mkdir -p ${POLICIES_PATH}
+
                 if [ $COMPONENT_TYPE == 'orderer' ]; then
-                  # This echo creates the access policy for orderers
-                  echo "{\"policy\":\"path \\\"${VAULT_SECRET_PATH}/crypto/ordererOrganizations/${COMPONENT_NAME}/*\\\" {\n capabilities = [\\\"list\\\", \\\"read\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/*\\\" {\n capabilities = [\\\"list\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/crypto/peerOrganizations/*\\\" {\n capabilities = [\\\"deny\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/credentials/${COMPONENT_NAME}/*\\\" {\n capabilities = [\\\"list\\\", \\\"read\\\"]\n}\"}" > payload.json  
+                  
+                  # This command writes the policies to the vault
+                  curl \
+                  --header "X-Vault-Token: $ROOT_TOKEN" \
+                  --request POST \
+                  --data @${POLICIES_PATH}/policies-config-orderer.json.tmpl \
+                  ${VAULT_ADDR}/v1/sys/policy/${POLICY_NAME}
+
                 fi;
 
                 if [ $COMPONENT_TYPE == 'peer' ]; then
-                  # This echo creates the access policy for peers
-                  echo "{\"policy\":\"path \\\"${VAULT_SECRET_PATH}/*\\\" {\n capabilities = [\\\"list\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/crypto/ordererOrganizations/*\\\" {\n capabilities = [\\\"deny\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/credentials/${COMPONENT_NAME}/*\\\" {\n capabilities = [\\\"list\\\", \\\"read\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/crypto/peerOrganizations\\\" {\n capabilities = [\\\"deny\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/crypto/peerOrganizations/*\\\" {\n capabilities = [\\\"deny\\\"]\n} \
-                  \npath \\\"${VAULT_SECRET_PATH}/crypto/peerOrganizations/${COMPONENT_NAME}/*\\\" {\n capabilities = [\\\"list\\\", \\\"read\\\"]\n}\"}" > payload.json
-                fi;
 
-                # This command writes the policies to the vault
-                curl \
-                --header "X-Vault-Token: $ROOT_TOKEN" \
-                --request POST \
-                --data @payload.json \
-                ${VAULT_ADDR}/v1/sys/policy/${POLICY_NAME}
+                  # This command writes the policies to the vault
+                  curl \
+                  --header "X-Vault-Token: $ROOT_TOKEN" \
+                  --request POST \
+                  --data @${POLICIES_PATH}/policies-config-peer.json.tmpl \
+                  ${VAULT_ADDR}/v1/sys/policy/${POLICY_NAME}
+
+                fi;
 
                 # Check policy
                 response_status=$(curl -s -o /dev/null -w "%{http_code}" \
                 --header "X-Vault-Token: $ROOT_TOKEN" \
                 ${VAULT_ADDR}/v1/sys/policy/${POLICY_NAME});
-
-                rm payload.json
 
                 validateVaultResponse ${response_status};
               fi;
@@ -173,3 +189,10 @@ spec:
             
                 validateVaultResponse ${response_status};
               fi;
+          volumeMounts:
+            - name: policies-config-orderer
+              mountPath: /policies/policies-config-orderer.json.tmpl
+              subPath: policies-config-orderer.json.tmpl
+            - name: policies-config-peer
+              mountPath: /policies/policies-config-peer.json.tmpl
+              subPath: policies-config-peer.json.tmpl

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/orderer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/orderer/tasks/orderer.yaml
@@ -198,7 +198,9 @@
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
   register: ambassador_orderer_secrets
-  when: not vault_orderer_ambassador.failed  
+  when:   
+    - network.env.proxy == 'ambassador'
+    - not vault_orderer_ambassador.failed 
 
 - name: Get Orderer ambassador info
   include_role: 

--- a/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/peer.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/crypto/peer/tasks/peer.yaml
@@ -94,7 +94,9 @@
     VAULT_ADDR: "{{ vault.url }}"
     VAULT_TOKEN: "{{ vault.root_token }}"
   register: ambassador_peer_secrets
-  when: not vault_peer_ambassador.failed  
+  when: 
+    - network.env.proxy == 'ambassador'
+    - not vault_peer_ambassador.failed
 
 - name: Get peer ambassador info
   include_role: 

--- a/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
+++ b/platforms/hyperledger-fabric/configuration/roles/create/genesis/tasks/main.yaml
@@ -20,7 +20,7 @@
 
 - name: "Write genesis block to Vault"  
   shell: |
-    vault write {{ org.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ org.name }}-net {{ network.env.type }}GenesisBlock=@{{build_path}}/channel-artifacts/genesis.block.base64
+    vault kv put {{ org.vault.secret_path | default('secret') }}/crypto/ordererOrganizations/{{ org.name }}-net {{ network.env.type }}GenesisBlock=@{{build_path}}/channel-artifacts/genesis.block.base64
   environment:
     VAULT_ADDR: "{{ org.vault.url }}"
     VAULT_TOKEN: "{{ org.vault.root_token }}"

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca_server_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/ca_server_job.tpl
@@ -24,8 +24,8 @@ spec:
       role: vault-role
       address: {{ vault.url }}
       authpath: {{ network.env.type }}{{ component_ns }}-auth
-      secretcryptoprefix: {{ vault.secret_path | default('secret') }}/crypto/{{ component_type }}Organizations/{{ component }}-net/ca
-      secretcredentialsprefix: {{ vault.secret_path | default('secret') }}/credentials/{{ component }}-net/ca/{{ component }}
+      secretcryptoprefix: {{ vault.secret_path | default('secret') }}/data/crypto/{{ component_type }}Organizations/{{ component }}-net/ca
+      secretcredentialsprefix: {{ vault.secret_path | default('secret') }}/data/credentials/{{ component }}-net/ca/{{ component }}
       serviceaccountname: vault-auth
       imagesecretname: regcred
       

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/install_chaincode_job.tpl
@@ -33,7 +33,7 @@ spec:
       orderersecretprefix: {{ vault.secret_path | default('secret') }}/data/crypto/peerOrganizations/{{ namespace }}/orderer
       serviceaccountname: vault-auth
       imagesecretname: regcred
-      secretgitprivatekey: {{ vault.secret_path | default('secret') }}/metadata/credentials/{{ namespace }}/git?git_password
+      secretgitprivatekey: {{ vault.secret_path | default('secret') }}/data/credentials/{{ namespace }}/git?git_password
       tls: false
     orderer:
       address: {{ orderer_address }}

--- a/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
+++ b/platforms/hyperledger-fabric/configuration/roles/helm_component/templates/value_peer.tpl
@@ -67,10 +67,10 @@ spec:
       address: {{ vault.url }}
       authpath: {{ network.env.type }}{{ namespace }}-auth
       secretprefix: {{ vault.secret_path | default('secret') }}/data/crypto/peerOrganizations/{{ namespace }}/peers/{{ peer_name }}.{{ namespace }}
-      secretambassador: {{ vault.secret_path | default('secret') }}/crypto/peerOrganizations/{{ namespace }}/ambassador
+      secretambassador: {{ vault.secret_path | default('secret') }}/data/crypto/peerOrganizations/{{ namespace }}/ambassador
       serviceaccountname: vault-auth
       imagesecretname: regcred
-      secretcouchdbpass: {{ vault.secret_path | default('secret') }}/metadata/credentials/{{ namespace }}/couchdb/{{ name }}?user
+      secretcouchdbpass: {{ vault.secret_path | default('secret') }}/data/credentials/{{ namespace }}/couchdb/{{ name }}?user
 
     service:
       servicetype: ClusterIP


### PR DESCRIPTION
Signed-off-by: mgCepeda <marina.gomez.cepeda@accenture.com>

**Changelog**
- Add configmap in charts /vault_kubernetes
- Fix create/crypto/orderer  and create/crypto/peer (add a new condition in task Get all ambassador secrets from Vault) 
- Fix create/genesis in main.yaml change vault write for vault kv put in task "Create genesis block"
- Fix value_per.tpl and install_chaincode_job.tpl change metadata for data in vault paths
- Update vault_kubernetes_job and ca_server_job to vaultv2


 

**Reviewed by**
@alvaropicazo 
@suvajit-sarkar 


 

**Linked issue**
#1657 
