### PR TITLE
[corda] fixed node/notary registration charts using roottoken

### DIFF
--- a/docs/source/architectureref/certificates_path_list_corda.md
+++ b/docs/source/architectureref/certificates_path_list_corda.md
@@ -6,62 +6,62 @@
 Certificate Paths on Vault for Corda Network
 ---------------------------------------------
 
-* Optionally, `secret_path` can be set on the network.yaml to change the secret engine from the default `secretsv2/`.
+* Secrets engine kv path for each organization services (networkmap, doorman, notary, nodes) are enabled via the automation.
 
 ### For Networkmap 
 
-| Path (networkmap crypto material) | Crypto-material         | Type        |
-|-----------------------------------|-------------------------|-------------|
-| /secretsv2/networkmap/certs         | networkmap.jks          | Certificate |
-| /secretsv2/networkmap/certs         | cacerts                 | Certificate |
-| /secretsv2/networkmap/certs         | keystore                | Certificate |
-| /secretsv2/networkmap/certs         | rootcakey               | Private key |
-| /secretsv2/networkmap/tlscerts      | tlscacerts              | Certificate |
-| /secretsv2/networkmap/tlscerts      | tlskey                  | Private key |
+| Path (networkmap crypto material)          | Crypto-material         | Type        |
+|--------------------------------------------|-------------------------|-------------|
+| /`networkmap.name_lowercase`/certs         | networkmap.jks          | Certificate |
+| /`networkmap.name_lowercase`/certs         | cacerts                 | Certificate |
+| /`networkmap.name_lowercase`/certs         | keystore                | Certificate |
+| /`networkmap.name_lowercase`/certs         | rootcakey               | Private key |
+| /`networkmap.name_lowercase`/tlscerts      | tlscacerts              | Certificate |
+| /`networkmap.name_lowercase`/tlscerts      | tlskey                  | Private key |
 
 ----
 ### For Doorman 
 
-| Path (doorman crypto material) | Crypto-material         | Type        |
-|--------------------------------|-------------------------|-------------|
-| /secretsv2/doorman/certs         | doorman.jks             | Certificate |
-| /secretsv2/doorman/certs         | cacerts                 | Certificate |
-| /secretsv2/doorman/certs         | keystore                | Certificate |
-| /secretsv2/doorman/certs         | rootcakey               | private key |
-| /secretsv2/doorman/tlscerts      | tlscacerts              | Certificate |
-| /secretsv2/doorman/tlscerts      | tlskey                  | Private key |
+| Path (doorman crypto material)          | Crypto-material         | Type        |
+|-----------------------------------------|-------------------------|-------------|
+| /`doorman.name_lowercase`/certs         | doorman.jks             | Certificate |
+| /`doorman.name_lowercase`/certs         | cacerts                 | Certificate |
+| /`doorman.name_lowercase`/certs         | keystore                | Certificate |
+| /`doorman.name_lowercase`/certs         | rootcakey               | private key |
+| /`doorman.name_lowercase`/tlscerts      | tlscacerts              | Certificate |
+| /`doorman.name_lowercase`/tlscerts      | tlskey                  | Private key |
 
 -----
 ### For Notary organization 
 
-| Path (notary crypto material)              | Crypto-material        | Type        |
-|--------------------------------------------|------------------------|-------------|
-| /secretsv2/notary/certs                      | Notary.cer             | Certificate |
-| /secretsv2/notary/certs                      | Notary.key             | Private key |
-| /secretsv2/notary/certs/customnodekeystore   | nodekeystore.jks       | Certificate |
-| /secretsv2/notary/certs/doorman              | doorman.crt            | Certificate |
-| /secretsv2/notary/certs/networkmap           | networkmap.crt         | Certificate |
-| /secretsv2/notary/certs/networkmaptruststore | network-map-truststore | Certificate |
-| /secretsv2/notary/certs/nodekeystore         | nodekeystore.jks       | Certificate |
-| /secretsv2/notary/certs/sslkeystore          | sslkeystore.jks        | Certificate |
-| /secretsv2/notary/certs/truststore           | truststore.jks         | Certificate |
-| /secretsv2/notary/tlscerts                   | tlscacerts             | Certificate |
-| /secretsv2/notary/tlscerts                   | tlskey                 | Private key |
+| Path (notary crypto material)                       | Crypto-material        | Type        |
+|-----------------------------------------------------|------------------------|-------------|
+| /`notary.name_lowercase`/certs                      | Notary.cer             | Certificate |
+| /`notary.name_lowercase`/certs                      | Notary.key             | Private key |
+| /`notary.name_lowercase`/certs/customnodekeystore   | nodekeystore.jks       | Certificate |
+| /`notary.name_lowercase`/certs/doorman              | doorman.crt            | Certificate |
+| /`notary.name_lowercase`/certs/networkmap           | networkmap.crt         | Certificate |
+| /`notary.name_lowercase`/certs/networkmaptruststore | network-map-truststore | Certificate |
+| /`notary.name_lowercase`/certs/nodekeystore         | nodekeystore.jks       | Certificate |
+| /`notary.name_lowercase`/certs/sslkeystore          | sslkeystore.jks        | Certificate |
+| /`notary.name_lowercase`/certs/truststore           | truststore.jks         | Certificate |
+| /`notary.name_lowercase`/tlscerts                   | tlscacerts             | Certificate |
+| /`notary.name_lowercase`/tlscerts                   | tlskey                 | Private key |
 
 -----
 
 ### For Node/Peer Organization 
 
-| Path (`orgname_lowercase` crypto material)              | Crypto-material        | Type        |
-|--------------------------------------------------|------------------------|-------------|
-| /secretsv2/`orgname_lowercase`/certs                      | `orgname_lowercase`.cer       | Certificate |
-| /secretsv2/`orgname_lowercase`/certs                      | `orgname_lowercase`.key       | Private key |
-| /secretsv2/`orgname_lowercase`/certs/customnodekeystore   | nodekeystore.jks       | Certificate |
-| /secretsv2/`orgname_lowercase`/certs/doorman              | doorman.crt            | Certificate |
-| /secretsv2/`orgname_lowercase`/certs/networkmap           | networkmap.crt         | Certificate |
-| /secretsv2/`orgname_lowercase`/certs/networkmaptruststore | network-map-truststore | Certificate |
-| /secretsv2/`orgname_lowercase`/certs/nodekeystore         | nodekeystore.jks       | Certificate |
-| /secretsv2/`orgname_lowercase`/certs/sslkeystore          | sslkeystore.jks        | Certificate |
-| /secretsv2/`orgname_lowercase`/certs/truststore           | truststore.jks         | Certificate |
-| /secretsv2/`orgname_lowercase`/tlscerts                   | tlscacerts             | Certificate |
-| /secretsv2/`orgname_lowercase`/tlscerts                   | tlskey                 | Private key |
+| Path (`node.name_lowercase` crypto material)      | Crypto-material        | Type        |
+|---------------------------------------------------|------------------------|-------------|
+| /`node.name_lowercase`/certs                      | `node.name_lowercase`.cer       | Certificate |
+| /`node.name_lowercase`/certs                      | `node.name_lowercase`.key       | Private key |
+| /`node.name_lowercase`/certs/customnodekeystore   | nodekeystore.jks       | Certificate |
+| /`node.name_lowercase`/certs/doorman              | doorman.crt            | Certificate |
+| /`node.name_lowercase`/certs/networkmap           | networkmap.crt         | Certificate |
+| /`node.name_lowercase`/certs/networkmaptruststore | network-map-truststore | Certificate |
+| /`node.name_lowercase`/certs/nodekeystore         | nodekeystore.jks       | Certificate |
+| /`node.name_lowercase`/certs/sslkeystore          | sslkeystore.jks        | Certificate |
+| /`node.name_lowercase`/certs/truststore           | truststore.jks         | Certificate |
+| /`node.name_lowercase`/tlscerts                   | tlscacerts             | Certificate |
+| /`node.name_lowercase`/tlscerts                   | tlskey                 | Private key |

--- a/platforms/r3-corda/charts/node-initial-registration/templates/job.yaml
+++ b/platforms/r3-corda/charts/node-initial-registration/templates/job.yaml
@@ -102,8 +102,6 @@ spec:
                value: {{ $.Values.vault.role }}
              - name: BASE_DIR
                value: {{ $.Values.volume.baseDir }}
-             - name: RT_SECRET_PREFIX
-               value: {{ .Values.vault.tokensecretprefix }}
              - name: CERTS_SECRET_PREFIX
                value: {{ .Values.vault.certsecretprefix }}
              - name: JAVA_OPTIONS
@@ -119,10 +117,6 @@ spec:
             KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
             VAULT_TOKEN=$(curl -sS --request POST ${VAULT_ADDR}/v1/auth/${KUBERNETES_AUTH_PATH}/login -H "Content-Type: application/json" -d '{"role":"'"${VAULT_APP_ROLE}"'","jwt":"'"${KUBE_SA_TOKEN}"'"}' | jq -r 'if .errors then . else .auth.client_token end')
 
-            # get the root token from the vault, to upload secrets on vault
-            LOOKUP_PWD_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${RT_SECRET_PREFIX} | jq -r 'if .errors then . else . end')
-            ROOT_TOKEN=$(echo ${LOOKUP_PWD_RESPONSE} | jq -r '.data.data["rootToken"]')
-
             # perform check if certificates are ready or not, and upload certificate into vault when ready
             COUNTER=1
             cd ${BASE_DIR}/certificates
@@ -131,9 +125,9 @@ spec:
                 if [ -e nodekeystore.jks ] && [ -e sslkeystore.jks ] && [ -e truststore.jks ] && [ -e done.txt ]
                 then
                   echo "found certificates, performing vault put"
-                  (echo '{"data": {"nodekeystore.jks": "'; base64 ${BASE_DIR}/certificates/nodekeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${ROOT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/nodekeystore
-                  (echo '{"data": {"sslkeystore.jks": "'; base64 ${BASE_DIR}/certificates/sslkeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${ROOT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/sslkeystore
-                  (echo '{"data": {"truststore.jks": "'; base64 ${BASE_DIR}/certificates/truststore.jks; echo '"}}') | curl -H "X-Vault-Token: ${ROOT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/truststore
+                  (echo '{"data": {"nodekeystore.jks": "'; base64 ${BASE_DIR}/certificates/nodekeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${VAULT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/nodekeystore
+                  (echo '{"data": {"sslkeystore.jks": "'; base64 ${BASE_DIR}/certificates/sslkeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${VAULT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/sslkeystore
+                  (echo '{"data": {"truststore.jks": "'; base64 ${BASE_DIR}/certificates/truststore.jks; echo '"}}') | curl -H "X-Vault-Token: ${VAULT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/truststore
                   break
                 else
                   echo "certificates are not ready, sleeping for 10s"

--- a/platforms/r3-corda/charts/node-initial-registration/values.yaml
+++ b/platforms/r3-corda/charts/node-initial-registration/values.yaml
@@ -223,9 +223,6 @@ vault:
   #Eg. rpcusersecretprefix: bank1/credentials/rpcusers
   rpcusersecretprefix: 
   #Provide the secretprefix
-  #Eg. tokensecretprefix: bank1/credentials/vaultroottoken
-  tokensecretprefix: 
-  #Provide the secretprefix
   #Eg. keystoresecretprefix: bank1/credentials/keystore
   keystoresecretprefix: 
   #Provide the secretprefix

--- a/platforms/r3-corda/charts/node/values.yaml
+++ b/platforms/r3-corda/charts/node/values.yaml
@@ -234,9 +234,6 @@ vault:
   #Eg. rpcusersecretprefix: bank1/credentials/rpcusers
   rpcusersecretprefix: 
   #Provide the secretprefix
-  #Eg. tokensecretprefix: bank1/credentials/vaultroottoken
-  tokensecretprefix: 
-  #Provide the secretprefix
   #Eg. keystoresecretprefix: bank1/credentials/keystore
   keystoresecretprefix: 
   #Provide the secretprefix

--- a/platforms/r3-corda/charts/notary-initial-registration/templates/job.yaml
+++ b/platforms/r3-corda/charts/notary-initial-registration/templates/job.yaml
@@ -100,8 +100,6 @@ spec:
                value: {{ $.Values.vault.role }}
              - name: BASE_DIR
                value: {{ $.Values.volume.baseDir }}
-             - name: RT_SECRET_PREFIX
-               value: {{ .Values.vault.tokensecretprefix }}
              - name: CERTS_SECRET_PREFIX
                value: {{ .Values.vault.certsecretprefix }}
              - name: JAVA_OPTIONS
@@ -117,10 +115,6 @@ spec:
             KUBE_SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
             VAULT_TOKEN=$(curl -sS --request POST ${VAULT_ADDR}/v1/auth/${KUBERNETES_AUTH_PATH}/login -H "Content-Type: application/json" -d '{"role":"'"${VAULT_APP_ROLE}"'","jwt":"'"${KUBE_SA_TOKEN}"'"}' | jq -r 'if .errors then . else .auth.client_token end')
 
-            # get the root token from the vault, to upload secrets on vault
-            LOOKUP_PWD_RESPONSE=$(curl -sS --header "X-Vault-Token: ${VAULT_TOKEN}" ${VAULT_ADDR}/v1/${RT_SECRET_PREFIX} | jq -r 'if .errors then . else . end')
-            ROOT_TOKEN=$(echo ${LOOKUP_PWD_RESPONSE} | jq -r '.data.data["rootToken"]')
-
             # perform check if certificates are ready or not, and upload certificate into vault when ready
             COUNTER=1
             cd ${BASE_DIR}/certificates
@@ -129,9 +123,9 @@ spec:
                 if [ -e nodekeystore.jks ] && [ -e sslkeystore.jks ] && [ -e truststore.jks ] && [ -e done.txt ]
                 then
                   echo "found certificates, performing vault put"
-                  (echo '{"data": {"nodekeystore.jks": "'; base64 ${BASE_DIR}/certificates/nodekeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${ROOT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/nodekeystore
-                  (echo '{"data": {"sslkeystore.jks": "'; base64 ${BASE_DIR}/certificates/sslkeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${ROOT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/sslkeystore
-                  (echo '{"data": {"truststore.jks": "'; base64 ${BASE_DIR}/certificates/truststore.jks; echo '"}}') | curl -H "X-Vault-Token: ${ROOT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/truststore
+                  (echo '{"data": {"nodekeystore.jks": "'; base64 ${BASE_DIR}/certificates/nodekeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${VAULT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/nodekeystore
+                  (echo '{"data": {"sslkeystore.jks": "'; base64 ${BASE_DIR}/certificates/sslkeystore.jks; echo '"}}') | curl -H "X-Vault-Token: ${VAULT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/sslkeystore
+                  (echo '{"data": {"truststore.jks": "'; base64 ${BASE_DIR}/certificates/truststore.jks; echo '"}}') | curl -H "X-Vault-Token: ${VAULT_TOKEN}" -d @- ${VAULT_ADDR}/v1/${CERTS_SECRET_PREFIX}/truststore
                   break
                 else
                   echo "certificates are not ready, sleeping for 10s"

--- a/platforms/r3-corda/charts/notary-initial-registration/values.yaml
+++ b/platforms/r3-corda/charts/notary-initial-registration/values.yaml
@@ -195,9 +195,6 @@ vault:
   #Eg. rpcusersecretprefix: bank1/credentials/rpcusers
   rpcusersecretprefix: 
   #Provide the secretprefix
-  #Eg. tokensecretprefix: bank1/credentials/vaultroottoken
-  tokensecretprefix: 
-  #Provide the secretprefix
   #Eg. keystoresecretprefix: bank1/credentials/keystore
   keystoresecretprefix: 
   #Provide the secretprefix

--- a/platforms/r3-corda/charts/notary/values.yaml
+++ b/platforms/r3-corda/charts/notary/values.yaml
@@ -226,9 +226,6 @@ vault:
   #Eg. rpcusersecretprefix: bank1/credentials/rpcusers
   rpcusersecretprefix: 
   #Provide the secretprefix
-  #Eg. tokensecretprefix: bank1/credentials/vaultroottoken
-  tokensecretprefix: 
-  #Provide the secretprefix
   #Eg. keystoresecretprefix: bank1/credentials/keystore
   keystoresecretprefix: 
   #Provide the secretprefix

--- a/platforms/r3-corda/configuration/roles/create/certificates/node/Readme.md
+++ b/platforms/r3-corda/configuration/roles/create/certificates/node/Readme.md
@@ -139,14 +139,14 @@ This task generates the networkmap certificates.
 **when**:  It runs when *networkmap_result.failed* == True, i.e. nms certs are not present . 
 
 #### 13. Write credentials to vault
-This task writes the database, rpcusers, vaultroottoken, keystore and networkmappassword credentials in Vault.
+This task writes the database, rpcusers, keystore and networkmappassword credentials in Vault.
 
 ##### Input Variables
     *VAULT_ADDR: Contains Vault URL, Fetched using 'vault.' from network.yaml
     *VAULT_TOKEN: Contains Vault Token, Fetched using 'vault.' from network.yaml
     component_name: The name of node resource
 
-**shell**:  It writes the database, rpcusers, vaultroottoken, keystore and networkmappassword credentials in Vault .
+**shell**:  It writes the database, rpcusers, keystore and networkmappassword credentials in Vault .
 
 #### 13. Write cordapps credentials to vault
 This task writes the corapps repository userpass credentials in Vault.

--- a/platforms/r3-corda/configuration/roles/create/certificates/node/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/certificates/node/tasks/main.yaml
@@ -155,7 +155,6 @@
   shell: |
     vault kv put {{ component_name }}/credentials/database sa="newh2pass" {{ component_name }}User1="xyz1234" {{ component_name }}User2="xyz1236"
     vault kv put {{ component_name }}/credentials/rpcusers {{ component_name }}operations="usera" {{ component_name }}operations1="usera" {{ component_name }}operations2="usera" {{ component_name }}admin="usera"
-    vault kv put {{ component_name }}/credentials/vaultroottoken rootToken="{{ vault.root_token }}"
     vault kv put {{ component_name }}/credentials/keystore keyStorePassword="newpass" trustStorePassword="newpass" defaultTrustStorePassword="trustpass" defaultKeyStorePassword="cordacadevpass" sslkeyStorePassword="sslpass" ssltrustStorePassword="sslpass"
     vault kv put {{ component_name }}/credentials/networkmappassword sa="admin"
   environment:

--- a/platforms/r3-corda/configuration/roles/create/certificates/notary/Readme.md
+++ b/platforms/r3-corda/configuration/roles/create/certificates/notary/Readme.md
@@ -147,14 +147,14 @@ This task generates the networkmap certificates.
 **when**:  It runs when *networkmap_result.failed* == True, i.e. nms certs are not present . 
 
 #### 12. Write credentials to vault
-This task writes the database, rpcusers, vaultroottoken, keystore and networkmappassword credentials in Vault.
+This task writes the database, rpcusers, keystore and networkmappassword credentials in Vault.
 
 ##### Input Variables
     *VAULT_ADDR: Contains Vault URL, Fetched using 'vault.' from network.yaml
     *VAULT_TOKEN: Contains Vault Token, Fetched using 'vault.' from network.yaml
     component_name: The name of node resource
 
-**shell**:  It writes the database, rpcusers, vaultroottoken, keystore and networkmappassword credentials in Vault .
+**shell**:  It writes the database, rpcusers, keystore and networkmappassword credentials in Vault .
 
 #### 13. Write cordapps credentials to vault
 This task writes the corapps repository userpass credentials in Vault.

--- a/platforms/r3-corda/configuration/roles/create/certificates/notary/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/create/certificates/notary/tasks/main.yaml
@@ -156,7 +156,6 @@
   shell: |
     vault kv put {{ component_name }}/credentials/database sa="newh2pass" notaryUser1="xyz1234" notaryUser2="xyz1236"
     vault kv put {{ component_name }}/credentials/rpcusers {{ component_name }}operations="usera" {{ component_name }}operations1="usera" {{ component_name }}operations2="usera" {{ component_name }}admin="usera"
-    vault kv put {{ component_name }}/credentials/vaultroottoken rootToken="{{ vault.root_token }}"
     vault kv put {{ component_name }}/credentials/keystore keyStorePassword="newpass" trustStorePassword="newpass" defaultTrustStorePassword="trustpass" defaultKeyStorePassword="cordacadevpass" sslkeyStorePassword="sslpass" ssltrustStorePassword="sslpass"
     vault kv put {{ component_name }}/credentials/networkmappassword sa="admin"
   environment:

--- a/platforms/r3-corda/configuration/roles/create/node_component/templates/job.tpl
+++ b/platforms/r3-corda/configuration/roles/create/node_component/templates/job.tpl
@@ -107,7 +107,6 @@ spec:
       serviceaccountname: vault-auth
       dbsecretprefix: {{ component_name }}/data/credentials/database
       rpcusersecretprefix: {{ component_name }}/data/credentials/rpcusers
-      tokensecretprefix: {{ component_name }}/data/credentials/vaultroottoken
       keystoresecretprefix: {{ component_name }}/data/credentials/keystore
       certsecretprefix: {{ component_name }}/data/certs
         

--- a/platforms/r3-corda/configuration/roles/create/node_component/templates/node.tpl
+++ b/platforms/r3-corda/configuration/roles/create/node_component/templates/node.tpl
@@ -129,7 +129,6 @@ spec:
       serviceaccountname: vault-auth
       dbsecretprefix: {{ component_name }}/data/credentials/database
       rpcusersecretprefix: {{ component_name }}/data/credentials/rpcusers
-      tokensecretprefix: {{ component_name }}/data/credentials/vaultroottoken
       keystoresecretprefix: {{ component_name }}/data/credentials/keystore
       certsecretprefix: {{ component_name }}/data/certs
       networkmapsecretprefix: {{ component_name }}/data/credentials/networkmappassword

--- a/platforms/r3-corda/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
+++ b/platforms/r3-corda/configuration/roles/setup/vault_kubernetes/tasks/main.yaml
@@ -140,7 +140,7 @@
   shell: |
     cd ./build    
     echo "path \"{{ component_name }}/data/*\" {
-        capabilities = [\"read\", \"list\"]
+        capabilities = [\"read\", \"list\", \"create\", \"update\"]
     }"  >>  vault-crypto-{{ component_name }}-ro.hcl
   environment:
     VAULT_ADDR: "{{ vault.url }}"


### PR DESCRIPTION
Signed-off-by: suvajit-sarkar <suvajit.sarkar@accenture.com>

**Changelog**
- Fix/removed root token being used in store-certs post registration
- Added create and update capabilities in policy to vault auth token

 

**Reviewed by**
@sownak 

 

**Linked issue**
#1713 
