### PR TITLE
[corda-ent] created ansible roles for the CENM Auth service

### DIFF
--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
@@ -1,0 +1,84 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+	name: {{ component_name }}
+	namespace: cenm-ent
+	annotations:
+		fluxcd.io/automated: "false"
+spec:
+	releaseName: {{ component_name }}
+	chart:
+		git: {{ org.gitops.git_url }}
+		ref: {{ org.gitops.branch }}
+		path: {{ charts_dir }}/auth
+	values:
+		bashDebug: false
+		prefix: cenm
+		nodeName: auth
+		authImage:
+      repository: corda/enterprise-auth
+      tag: 1.5.1-zulu-openjdk8u242
+      pullPolicy: Always
+    image:
+      initContainerName: {{ network.docker.url }}/{{ init_image }}
+      mainContainerName: {{ network.docker.url }}/{{ docker_image }}
+      imagePullSecret: regcred
+    config:
+      volume:
+        baseDir: /opt/cenm
+        replicas: 1
+      
+		vault:
+      address: {{ vault.url }}
+      role: vault-role
+      authpath: cordaent{{ org.type | lower }}
+      serviceaccountname: vault-auth
+      certsecretprefix: {{ vault.secret_path | default('secretsv2') }}/data/{{ org.type | lower }}
+      retries: 20
+      sleepTimeAfterError: 20
+
+		database:
+			driverClassName: "org.h2.Driver"
+			jdbcDriver: ""
+			url: "jdbc:h2:file:./h2/auth-persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=0;AUTO_SERVER_PORT=0"
+			user: "testuser"
+			password: "password"
+			runMigration: true
+		volume:
+			volumeSizeAuthEtc: 1Gi
+			volumeSizeAuthH2: 5Gi
+			volumeSizeAuthLogs: 5Gi
+		storageClass: cordaentsc
+		sleepTimeAfterError: 300
+		logsContainerEnabled: true
+
+    podSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+
+    securityContext: {}
+     
+		nameOverride: ""
+		fullnameOverride: ""
+
+		service:
+			type: ClusterIP
+			port: 8081
+		resources:
+			limits: 2Gi
+			requests: 2Gi
+		livenessProbe:
+			enabled: false
+			failureThreshold: 3
+			initialDelaySeconds: 10
+			periodSeconds: 10
+			successThreshold: 1
+			timeoutSeconds: 1
+		readinessProbe:
+			enabled: false
+			failureThreshold: 3
+			initialDelaySeconds: 10
+			periodSeconds: 10
+			successThreshold: 1
+			timeoutSeconds: 1

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
@@ -1,8 +1,8 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-	name: {{ component_name }}
-	namespace: cenm-ent
+	name: {{ org.services.auth.name }}
+	namespace: {{ component_ns }}
 	annotations:
 		fluxcd.io/automated: "false"
 spec:
@@ -27,6 +27,8 @@ spec:
       volume:
         baseDir: /opt/cenm
         replicas: 1
+		subjects:
+			auth: "{{ services.auth.subject }}"
       
 		vault:
       address: {{ vault.url }}

--- a/platforms/r3-corda-ent/configuration/roles/setup/auth/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/auth/tasks/main.yaml
@@ -1,0 +1,3 @@
+# This role creates value files for the auth chart and pushes it into the git repisitory
+
+# Waiting for the PKI job to con

--- a/platforms/r3-corda-ent/configuration/roles/setup/auth/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/auth/tasks/main.yaml
@@ -1,3 +1,46 @@
 # This role creates value files for the auth chart and pushes it into the git repisitory
 
-# Waiting for the PKI job to con
+# This task checks if certs and crypto are there in the vault or not
+- name: Check if auth certificates are present in the vault
+  shell: |
+    vault kv get -field=corda-ssl-auth-keys.jks {{ org.vault.secret_path | default('secretsv2') }}/{{ org.name | lower }}/root/certs
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+  register: auth_certs
+
+# This task waits for the PKI job to complete
+- name: "Wait for PKI job to complete"
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configurations/roles/check/helm_component"
+  vars:
+    component_type: "Job"
+    namespace: "{{ component_ns }}"
+    component_name: "{{ org.name | lower }}-generate-pki"
+    kubernetes: "{{ org.k8s }}"
+  when: auth_certs.failed
+
+# This task creates the helm release files for the Auth service
+- name: "Create Auth helm release files"
+  include_role:
+    name: helm_component
+  vars:
+    type: "auth"
+    chart: "auth"
+    corda_service_version: auth-{{ org.version }}
+    name: "{{ org.name | lower }}"
+    component_name: "{{ org.services.auth.name }}"
+    charts_dir: "{{ org.gitops.chart_source }}"
+    vault: "{{ org.vault }}"
+    component_auth:  #is this needed?
+    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
+    helm_lint: "true"
+
+# Push the created deployment files to git repository
+- name: "Push deployment files to git"
+  include_role: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
+  vars:
+    GIT_DIR: "{{ playbook_dir }}/../../../"
+    gitops: "{{ org.gitops }}"
+    GIT_RESET_PATH: "platforms/r3-corda-ent/configuration"
+    msg: "[ci skip] Pushing deployment files for auth service"

--- a/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
@@ -67,6 +67,10 @@
     name: "setup/pki-generator"
   when: root_certs.failed
 
+- name: "Deploy Auth Service"
+  include_role:
+    name: "setup/auth"
+
 # Deploy Signer node
 - name: Deploy Signer service
   include_role:


### PR DESCRIPTION
**Changelog**
- Added an ansible role for the Auth service and an Auth tpl file for its automation
- Updated the Ansible setup/cenm role to include a task for the deployment of the Auth service

 

**Reviewed by**
@suvajit-sarkar @sownak 

 

**Linked issue**
#1726 
