### PR TITLE
[corda-ent] Auth service automation added and readme file

### DIFF
--- a/platforms/r3-corda-ent/charts/auth/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/auth/templates/deployment.yaml
@@ -116,6 +116,9 @@ spec:
               memory: {{ .Values.config.pod.resources.requests }}
             limits:
               memory: {{ .Values.config.pod.resources.limits }}
+          volumeMounts:
+          - name: auth-etc
+            mountPath: {{ .Values.config.volume.baseDir }}/etc
       containers:
         - name: main
           securityContext:

--- a/platforms/r3-corda-ent/charts/auth/templates/deployment.yaml
+++ b/platforms/r3-corda-ent/charts/auth/templates/deployment.yaml
@@ -112,10 +112,10 @@ spec:
             #[TODO] : The JWT creation can be moved to PKI Job
             keytool -genkeypair -alias oauth-test-jwt -keyalg RSA -keypass password -keystore etc/jwt-store.jks -storepass password -dname "{{ .Values.authSubject }}"
           resources:
-            {{- toYaml .Values.config.pod.resources | nindent 12 }}
-          volumeMounts:
-          - name: auth-etc
-            mountPath: {{ .Values.config.volume.baseDir }}/etc
+            requests:
+              memory: {{ .Values.config.pod.resources.requests }}
+            limits:
+              memory: {{ .Values.config.pod.resources.limits }}
       containers:
         - name: main
           securityContext:
@@ -161,7 +161,10 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end  }}
           resources:
-            {{- toYaml .Values.config.pod.resources | nindent 12 }}
+            requests:
+              memory: {{ .Values.config.pod.resources.requests }}
+            limits:
+              memory: {{ .Values.config.pod.resources.limits }}
         {{- if .Values.config.logsContainersEnabled }}
         - name: logs-auth
           securityContext:
@@ -179,7 +182,10 @@ spec:
           - name: auth-logs
             mountPath: {{ .Values.config.volume.baseDir }}/logs
           resources:
-            {{- toYaml .Values.config.pod.resources | nindent 12 }}
+            requests:
+              memory: {{ .Values.config.pod.resources.requests }}
+            limits:
+              memory: {{ .Values.config.pod.resources.limits }}
         {{- end  }}
       volumes:
         - name: auth-conf

--- a/platforms/r3-corda-ent/charts/auth/values.yaml
+++ b/platforms/r3-corda-ent/charts/auth/values.yaml
@@ -147,11 +147,7 @@ config:
   pod:  
     resources:
       limits:
-      #   cpu: 100m
-        memory: 
       requests:
-      #   cpu: 100m
-        memory: 
 
   nodeSelector: {}
 

--- a/platforms/r3-corda-ent/charts/auth/values.yaml
+++ b/platforms/r3-corda-ent/charts/auth/values.yaml
@@ -117,14 +117,6 @@ config:
     # Eg. baseDir: /opt/corda
     baseDir: 
 
-  # Provide the path where the CENM Idman .jar-file is stored
-  # Eg. jarPath: bin
-  jarPath: 
-
-  # Provide the path where the CENM Service configuration files are stored
-  # Eg. configPath: etc
-  configPath: 
-
   # Provide any extra annotations for the PVCs
   pvc:
     #   annotations:

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
@@ -1,0 +1,71 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: {{ org.services.auth.name }}
+  namespace: {{ component_ns }}
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  releaseName: {{ component_name }}
+  chart:
+    git: {{ org.gitops.git_url }}
+    ref: {{ org.gitops.branch }}
+    path: {{ charts_dir }}/auth
+  values:
+    metadata: 
+      namespace: {{ component_ns }}
+      labels: {}
+    prefix: cenm
+    nodeName: auth
+    image:
+      initContainerName: {{ network.docker.url }}/{{ init_image }}
+      authContainerName: {{ network.docker.url }}/{{ docker_image }}
+      imagePullSecrets: 
+        - name: regcred
+      pullPolicy: IfNotPresent
+    storage: 
+      name: cordaentsc
+    vault:
+      address: {{ vault.url }}
+      role: vault-role
+      authPath: {{ component_auth }}
+      serviceAccountName: vault-auth
+      certSecretPrefix: {{ vault.secret_path | default('secretsv2') }}/data/{{ org.name | lower }}
+
+    database:
+      driverClassName: "org.h2.Driver"
+      jdbcDriver: ""
+      url: "jdbc:h2:file:./h2/auth-persistence;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000;WRITE_DELAY=0;AUTO_SERVER_PORT=0"
+      user: "{{ org.services.auth.name }}-db-user"
+      password: "{{ org.services.auth.name }}-db-password"
+      runMigration: "true"
+
+    config:
+      volume:
+        baseDir: /opt/cenm
+      replicas: 1
+
+      pvc:
+        annotations: {}
+        volumeSizeAuthEtc: 1Gi
+        volumeSizeAuthH2: 5Gi
+        volumeSizeAuthLogs: 5Gi
+      deployment:
+        annotations: {}
+      pod:
+        resources:
+          limits: 514Mi
+          requests: 514Mi
+      
+    storageClass: cordaentsc
+    sleepTimeAfterError: 300
+    logsContainerEnabled: true
+     
+    nameOverride: ""
+    fullnameOverride: ""
+
+    service:
+      type: ClusterIP
+      port: {{ org.services.auth.port }}
+
+    authSubject: "{{ org.services.auth.subject }}"

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/templates/auth.tpl
@@ -15,8 +15,8 @@ spec:
     metadata: 
       namespace: {{ component_ns }}
       labels: {}
-    prefix: cenm
-    nodeName: auth
+    prefix: {{ org.name }}
+    nodeName: {{ component_name }}
     image:
       initContainerName: {{ network.docker.url }}/{{ init_image }}
       authContainerName: {{ network.docker.url }}/{{ docker_image }}

--- a/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/helm_component/vars/main.yaml
@@ -7,6 +7,7 @@
 helm_templates:
   pki-generator: pki-generator.tpl
   pki-generator-node: pki-generator-node.tpl
+  auth: auth.tpl
   signer: signer.tpl
   idman: idman.tpl
   nmap: nmap.tpl
@@ -22,6 +23,7 @@ docker_images:
   cenm:
     pki-1.2: corda/enterprise-pki:1.2-zulu-openjdk8u242
     pki-1.5: corda/enterprise-pki:1.5.1-zulu-openjdk8u242
+    auth-1.5: corda/enterprise-auth:1.5.1-zulu-openjdk8u242
     signer-1.2: corda/enterprise-signer:1.2-zulu-openjdk8u242
     signer-1.5: corda/enterprise-signer:1.5.1-zulu-openjdk8u242
     networkmap-1.2: corda/enterprise-networkmap:1.2-zulu-openjdk8u242

--- a/platforms/r3-corda-ent/configuration/roles/setup/auth/README.md
+++ b/platforms/r3-corda-ent/configuration/roles/setup/auth/README.md
@@ -1,0 +1,60 @@
+[//]: # (##############################################################################################)
+[//]: # (Copyright Accenture. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: Apache-2.0)
+[//]: # (##############################################################################################)
+
+## ROLE: `setup/auth`
+This role creates deployment files Auth service and pushes the generated value files to into the repository.
+
+### Tasks
+(Variables with * are fetched from the playbook whivh is calling this role)
+
+(Loop variable: fetched from the playbook which is calling this role)
+
+---
+
+#### 1. Check if auth certificates are present in the vault
+This task checks if the auth certificates have already been created (written to the Vault).
+##### Input variables
+- *`VAULT_ADDR` - The Vault address
+- *`VAULT_TOKEN` - Vault root/custom token which has the access to the path
+##### Output variables
+- `auth_certs` - Variable that stores the result of the command (`auth_certs.failed` will be `true` when the certs do not exist yet)
+
+---
+
+#### 2. Wait for PKI job to complete
+This task waits for the PKI job to complete so the auth certs can be generated.
+##### Input variables
+- `component_type` - The type of component to check for, i.e. `Job`
+- `namespace` - The namespace where the component is deployed
+- `component_name` - The name of the component which is deployed
+- `kubernetes` - The resources of the K8s cluster (context and configuration file)
+
+**when** - This task is only run when there are no auth certificates yet, (e.g. `auth_certs.failed == true`)
+
+---
+
+#### 3. Create Auth helm release files
+This task creates deployment file for auth service by calling the `helm_component` role.
+##### Input Variables
+- `type` - The type of component to deploy, i.e. `auth`
+- `chart` - The name of the chart, i.e. `auth`
+- `corda_service_version` - The version of the auth service
+- `name` - The name of the organisation
+- `component_name` - The exact name of the component
+- `charts_dir` - The path to auth charts
+- `vault` - The information of the Vault for the organisation
+- `component_auth` - The auth of the component
+- `values_dir` - The directory where the release files are stored
+- `helm_lint` - Whether to lint the Helm chart, i.e. `true` 
+
+---
+
+#### 4. Push the created deployment files to repository
+This tasks pushes the created value files into repository by calling the shared `git_push` role.
+##### Input Variables
+- `GIT_DIR` - The base path of the GIT repository, default `{{ playbook_dir }}/../../../`
+- `GIT_RESET_PATH` - The path of the GIT repository, which is reset before committing. Default value is `platforms/r3-corda-ent/configuration`
+- `gitops` - *item.gitops* from `network.yaml`
+- `msg` - The commit message to use when pushing deployment files.

--- a/platforms/r3-corda-ent/configuration/roles/setup/auth/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/auth/tasks/main.yaml
@@ -1,0 +1,54 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+# This role creates value files for the auth chart and pushes it into the git repisitory
+
+# This task checks if certs and crypto are there in the vault or not
+- name: Check if auth certificates are present in the vault
+  shell: |
+    vault kv get -field=corda-ssl-auth-keys.jks {{ org.vault.secret_path | default('secretsv2') }}/{{ org.name | lower }}/root/certs
+  environment:
+    VAULT_ADDR: "{{ org.vault.url }}"
+    VAULT_TOKEN: "{{ org.vault.root_token }}"
+  register: auth_certs
+  ignore_errors: yes
+
+# This task waits for the PKI job to complete
+- name: "Wait for PKI job to complete"
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/check/helm_component"
+  vars:
+    component_type: "Job"
+    namespace: "{{ component_ns }}"
+    component_name: "{{ org.name | lower }}-generate-pki"
+    kubernetes: "{{ org.k8s }}"
+  when: auth_certs.failed
+
+# This task creates the helm release files for the Auth service
+- name: "Create Auth helm release files"
+  include_role:
+    name: helm_component
+  vars:
+    type: "auth"
+    chart: "auth"
+    corda_service_version: auth-{{ org.version }}
+    name: "{{ org.name | lower }}"
+    component_name: "{{ org.services.auth.name }}"
+    charts_dir: "{{ org.gitops.chart_source }}"
+    vault: "{{ org.vault }}"
+    component_auth: "cordaent{{ org.name | lower }}"
+    values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}"
+    helm_lint: "true"
+
+# Push the created deployment files to git repository
+- name: "Push deployment files to git"
+  include_role:
+    name: "{{ playbook_dir }}/../../shared/configuration/roles/git_push"
+  vars:
+    GIT_DIR: "{{ playbook_dir }}/../../../"
+    gitops: "{{ org.gitops }}"
+    GIT_RESET_PATH: "platforms/r3-corda-ent/configuration"
+    msg: "[ci skip] Pushing deployment files for auth service"

--- a/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
+++ b/platforms/r3-corda-ent/configuration/roles/setup/cenm/tasks/main.yaml
@@ -73,6 +73,11 @@
     name: "setup/pki-generator"
   when: root_certs.failed
 
+# Deploy Auth Service
+- name: "Deploy Auth Service"
+  include_role:
+    name: "setup/auth"
+
 # Deploy Zone service
 - name: Deploy Zone service
   include_role:

--- a/platforms/shared/configuration/roles/helm_lint/vars/main.yaml
+++ b/platforms/shared/configuration/roles/helm_lint/vars/main.yaml
@@ -59,3 +59,4 @@ charts:
   vault_kubernetes_job: vault_kubernetes
   crypto_ibft_job: crypto_ibft
   operations_console: operations_console
+  auth: auth


### PR DESCRIPTION
Signed-off-by: angelaalagbe <angela.alagbe@accenture.com>

**Changelog**
- Added auth service tpl file, ansible role, readme file, added task to deploy auth service to setup/cenm role
- 
- Updated the deployment file to use same helm version as BAF, updated the syntax of my tpl file to match the charts, updated the values file to match the tpl file, updated helm linting file to include auth service, updated helm_component variables file to include auth service details. 

 

**Reviewed by**
@suvajit-sarkar 

 

**Linked issue**
#1726 
