### PR TITLE
Fix Typos in Documentation for Shared Configuration Roles Setup

### DIFF
--- a/platforms/shared/configuration/roles/setup/Readme.md
+++ b/platforms/shared/configuration/roles/setup/Readme.md
@@ -96,7 +96,7 @@ This task creates a registory temporary directory. Stores the result in *tmp_dir
 This task checks if helmi is present or not. Stores the result in *helm_stat_result*.
 
 #### 3. Install helm
-If helm is not present i.e. *helm_stat_result* is false, it downloads the helm using specefied url.
+If helm is not present i.e. *helm_stat_result* is false, it downloads the helm using specified url.
 
 #### 4. Unzip helm archive
 This tasks unzips helm archive, runs only when helm is not found.

--- a/platforms/shared/configuration/roles/setup/Readme.md
+++ b/platforms/shared/configuration/roles/setup/Readme.md
@@ -4,7 +4,7 @@
 [//]: # (##############################################################################################)
 
 ## shared/configuration/roles/setup
-This folder contains common roles required for setting up necessery requirements.
+This folder contains common roles required for setting up necessary requirements.
 It contains following roles.
 ### Ambassador
 This roles setups Ambassador.


### PR DESCRIPTION


**Description:**  
This pull request corrects two typographical errors in the documentation file platforms/shared/configuration/roles/setup/Readme.md:
- "necesery" has been corrected to "necessary"
- "specfied" has been corrected to "specified"

These changes improve the clarity and professionalism of the documentation. No functional code changes are included.