### PR TITLE
feat(2671): Add tx pool type and cacheLastBlock params to besu config options

### DIFF
--- a/platforms/hyperledger-besu/charts/besu-node/templates/besu-config-configmap.yaml
+++ b/platforms/hyperledger-besu/charts/besu-node/templates/besu-config-configmap.yaml
@@ -26,10 +26,17 @@ data:
     logging={{ .Values.node.besu.logging | quote }}
     node-private-key-file={{.Values.node.besu.privateKeyPath | quote }}
     cache-last-blocks={{ .Values.node.besu.cacheLastBlocks }}
+    sync-min-peers{{ .Values.node.besu.syncMinPeers }}
 
     # Transaction Pool
     tx-pool={{ .Values.node.besu.txPool.type | quote }}
-    tx-pool-layer-max-capacity={{ .Values.node.besu.txPool.maxCapacity }}
+    {{ if eq .Values.node.besu.txPool.type "sequenced" -}}
+    tx-pool-max-size={{ .Values.node.besu.txPool.maxCapacity | quote }}
+    tx-pool-limit-by-account-percentage={{ .Values.node.besu.txPool.accountPercentage  }}
+    {{ else }}
+    tx-pool-layer-max-capacity={{ .Values.node.besu.txPool.maxCapacity | quote }}
+    tx-pool-max-future-by-sender={{ .Values.node.besu.txPool.accountPercentage | quote }}
+    {{ end }}
 
     {{ if  .Values.node.besu.p2p.enabled -}}
     # P2P network

--- a/platforms/hyperledger-besu/charts/besu-node/templates/besu-config-configmap.yaml
+++ b/platforms/hyperledger-besu/charts/besu-node/templates/besu-config-configmap.yaml
@@ -25,8 +25,10 @@ data:
     genesis-file={{ .Values.node.besu.genesisFilePath | quote }}
     logging={{ .Values.node.besu.logging | quote }}
     node-private-key-file={{.Values.node.besu.privateKeyPath | quote }}
+    cache-last-blocks={{ .Values.node.besu.cacheLastBlocks }}
 
     # Transaction Pool
+    tx-pool={{ .Values.node.besu.txPool.type | quote }}
     tx-pool-layer-max-capacity={{ .Values.node.besu.txPool.maxCapacity }}
 
     {{ if  .Values.node.besu.p2p.enabled -}}

--- a/platforms/hyperledger-besu/charts/besu-node/values.yaml
+++ b/platforms/hyperledger-besu/charts/besu-node/values.yaml
@@ -49,7 +49,7 @@ image:
   pullPolicy: IfNotPresent
   besu:
     repository: hyperledger/besu
-    tag: 23.10.2
+    tag: 24.12.2
   hooks:
     repository: ghcr.io/hyperledger/bevel-k8s-hooks
     tag: qgt-0.2.12
@@ -62,6 +62,7 @@ node:
   besu:
     identity: "supplychain"
     cacheLastBlocks: 0
+    syncMinPeers: 3 # as 4 peers min is needed for ibft/qbft consensus
     envBesuOpts: ""
     resources:
       cpuLimit: 0.25
@@ -107,6 +108,7 @@ node:
     txPool:
       type: ""
       maxCapacity: 12
+      accountPercentage: 200 #if txPool is sequenced, this has to be [0 to 1] Example: 0.5. By default is 0.4
     http:
       allowlist: '["*"]'
     metrics:

--- a/platforms/hyperledger-besu/charts/besu-node/values.yaml
+++ b/platforms/hyperledger-besu/charts/besu-node/values.yaml
@@ -61,6 +61,7 @@ node:
 
   besu:
     identity: "supplychain"
+    cacheLastBlocks: 0
     envBesuOpts: ""
     resources:
       cpuLimit: 0.25
@@ -104,6 +105,7 @@ node:
       port: 8547
       corsOrigins: '["all"]'
     txPool:
+      type: ""
       maxCapacity: 12
     http:
       allowlist: '["*"]'

--- a/platforms/hyperledger-besu/charts/values/proxy-and-vault/txnode.yaml
+++ b/platforms/hyperledger-besu/charts/values/proxy-and-vault/txnode.yaml
@@ -63,4 +63,4 @@ node:
 image:
   besu:
     repository: hyperledger/besu
-    tag: 23.10.2
+    tag: 24.12.2

--- a/platforms/hyperledger-besu/charts/values/proxy-and-vault/validator.yaml
+++ b/platforms/hyperledger-besu/charts/values/proxy-and-vault/validator.yaml
@@ -43,4 +43,4 @@ node:
 image:
   besu:
     repository: hyperledger/besu
-    tag: 23.10.2
+    tag: 24.12.2


### PR DESCRIPTION
Added:
 - tx pool type config option to choose between layered or sequenced. By default it will be layered if no param is provided.
 - cacheLastBlock to have the option to cache blocks. By default is 0.
 - Support for Besu 24.12.2+
 - Layer max capacity customizable for both layered and sequenced txPool types
 - Account percentage setting customizable for both layered and sequenced txPool types