### PR TITLE
fix(fabric): correct shared job template image vars

### DIFF
--- a/platforms/shared/configuration/roles/create/job_component/tasks/main.yaml
+++ b/platforms/shared/configuration/roles/create/job_component/tasks/main.yaml
@@ -45,7 +45,6 @@
       - "{{ values_dir }}/{{ component_name }}.yaml"
     force: true
     wait: true
-    update_repo_cache: true
     kubeconfig: "{{ kubernetes.config_file }}"
   when:
     - helm_check.status is not defined

--- a/platforms/shared/configuration/roles/create/job_component/templates/create_channel_job.tpl
+++ b/platforms/shared/configuration/roles/create/job_component/templates/create_channel_job.tpl
@@ -18,8 +18,8 @@ global:
     externalUrlSuffix: {{ org.external_url_suffix }}
 
 image:
-  fabricTools: {{ docker_url }}/{{ fabric_tools_image }}
-  alpineUtils: {{ docker_url }}/bevel-alpine:{{ bevel_alpine_version }}
+  fabricTools: {{ docker_url }}/{{ charts.fabric_tools_image }}
+  alpineUtils: {{ docker_url }}/bevel-alpine:{{ charts.bevel_alpine_version }}
 {% if network.docker.username is defined and network.docker.password is defined  %}
   pullSecret: regcred
 {% else %}

--- a/platforms/shared/configuration/roles/create/job_component/templates/fabric_genesis.tpl
+++ b/platforms/shared/configuration/roles/create/job_component/templates/fabric_genesis.tpl
@@ -18,8 +18,8 @@ global:
     externalUrlSuffix: {{ org.external_url_suffix }}
 
 image:
-  alpineUtils: {{ docker_url }}/bevel-alpine:{{ bevel_alpine_version }}
-  fabricTools: {{ docker_url }}/{{ fabric_tools_image }}
+  alpineUtils: {{ docker_url }}/bevel-alpine:{{ charts.bevel_alpine_version }}
+  fabricTools: {{ docker_url }}/{{ charts.fabric_tools_image }}
 {% if network.docker.username is defined and network.docker.password is defined  %}
   pullSecret: regcred
 {% else %}

--- a/platforms/shared/configuration/roles/create/job_component/templates/join_channel_job.tpl
+++ b/platforms/shared/configuration/roles/create/job_component/templates/join_channel_job.tpl
@@ -18,8 +18,8 @@ global:
     externalUrlSuffix: {{ org.external_url_suffix }}
 
 image:
-  fabricTools: {{ docker_url }}/{{ fabric_tools_image }}
-  alpineUtils: {{ docker_url }}/bevel-alpine:{{ bevel_alpine_version }}
+  fabricTools: {{ docker_url }}/{{ charts.fabric_tools_image }}
+  alpineUtils: {{ docker_url }}/bevel-alpine:{{ charts.bevel_alpine_version }}
 {% if network.docker.username is defined and network.docker.password is defined  %}
   pullSecret: regcred
 {% else %}

--- a/platforms/shared/configuration/roles/create/job_component/templates/osn_create_channel_job.tpl
+++ b/platforms/shared/configuration/roles/create/job_component/templates/osn_create_channel_job.tpl
@@ -18,8 +18,8 @@ global:
     externalUrlSuffix: {{ org.external_url_suffix }}
 
 image:
-  fabricTools: {{ docker_url }}/{{ fabric_tools_image }}
-  alpineUtils: {{ docker_url }}/bevel-alpine:{{ bevel_alpine_version }}
+  fabricTools: {{ docker_url }}/{{ charts.fabric_tools_image }}
+  alpineUtils: {{ docker_url }}/bevel-alpine:{{ charts.bevel_alpine_version }}
 {% if network.docker.username is defined and network.docker.password is defined  %}
   pullSecret: regcred
 {% else %}


### PR DESCRIPTION
## Summary

Fix the Fabric minikube deployment regressions from issue #2659 that are still reproducible in the shared job component templates.

## Changes

- update the Fabric genesis/channel job templates to read `fabric_tools_image` and `bevel_alpine_version` from `charts.*`, which matches how these values are defined in the shared role vars
- remove the unconditional `update_repo_cache: true` from the shared Helm install task so local/chart-path installs do not fail when no Helm repo has been added

## Notes

- the `create-join-channel.yaml` playbook paths referenced in the report still exist in the current tree, so this PR keeps scope to the two concrete repo-level failures I could confirm directly

Fixes #2659