### PR TITLE
fix(fabric): add missing channel jobs to deploy playbook

### DIFF
--- a/platforms/hyperledger-fabric/configuration/deploy-network.yaml
+++ b/platforms/hyperledger-fabric/configuration/deploy-network.yaml
@@ -130,6 +130,42 @@
         kubernetes: "{{ org.k8s  }}"
         generateGenisis: true
 
+    # This role creates the value file for creating channel from creator organization
+    # to the vault.
+    - name: Create all create-channel jobs
+      include_role:
+        name: "create/channels"
+      vars:
+        build_path: "./build"
+        participants: "{{ item.participants }}"
+        docker_url: "{{ network.docker.url }}"
+        channel_name: "{{ item.channel_name | lower }}"
+      loop: "{{ network['channels'] }}"
+      when: item.channel_status == 'new' and ('2.2.' in network.version or '1.4.' in network.version)
+
+    # This role creates the value file for creating channel from creator organization
+    # to the vault.
+    - name: Create all osnadmin create-channel jobs
+      include_role:
+        name: "create/osnchannels"
+      vars:
+        build_path: "./build"
+        docker_url: "{{ network.docker.url }}"
+      loop: "{{ network['channels'] }}"
+      when: item.channel_status == 'new' and '2.5.' in network.version
+
+    # This role creates the value file for joining channel from each participating peer
+    # to the vault.
+    - name: Create all join-channel jobs
+      include_role:
+        name: "create/channels_join"
+      vars:
+        build_path: "./build"
+        participants: "{{ item.participants }}"
+        docker_url: "{{ network.docker.url }}"
+      loop: "{{ network['channels'] }}"
+      when: item.channel_status == 'new'
+
   vars: #These variables can be overriden from the command line
     privilege_escalate: false           #Default to NOT escalate to root privledges
     install_os: "linux"                 #Default to linux OS


### PR DESCRIPTION
## Summary

Restore the missing Fabric channel creation/join jobs in `deploy-network.yaml` so initial network deployment actually schedules the channel jobs described in issue #2634.

## Changes

- add the `create/channels` step back into `deploy-network.yaml` for Fabric 1.4/2.2 networks
- add the `create/osnchannels` step for Fabric 2.5 networks
- add the `create/channels_join` step so peer join jobs are generated during initial deploy
- mirror the same channel-job flow that already exists in `add-new-channel.yaml`

Fixes #2634