### PR TITLE
fix(fabric): deploy console sidecar for backend apis

### DIFF
--- a/docs/source/guides/fabric/deploy-operations-console.md
+++ b/docs/source/guides/fabric/deploy-operations-console.md
@@ -14,6 +14,7 @@
 ## Prerequisites
 The [Fabric Operations Console](https://github.com/hyperledger-labs/fabric-operations-console) can be deployed along with the Fabric Network. 
 You can then manually add peers, orderers, CA to the console by importing appropriate JSON files.
+Bevel deploys the console together with the required `fabric-deployer` sidecar so channel and ordering-service workflows can use the backend deployer APIs out of the box.
 
 The Helm Chart for Fabric Operations Console is available [here](https://github.com/hyperledger/bevel/blob/main/platforms/hyperledger-fabric/charts/fabric-operations-console).
 

--- a/platforms/hyperledger-fabric/charts/fabric-operations-console/README.md
+++ b/platforms/hyperledger-fabric/charts/fabric-operations-console/README.md
@@ -57,9 +57,9 @@ operation_console/
 - `templates/`: Contains the Kubernetes manifest templates that define the resources to be deployed.
 - `helpers.tpl`: Contains custom label definitions used in other templates.
 - `configmap.yaml`: Store configuration for the fabric-console
-- `deployment.yaml`: Defines a StatefulSet with one replica that manages three containers: couchdb, fabric-console, and configtxlator. The couchdb container will be used to store the data for the Fabric network and it will be exposed on port 5984. The fabric-console container will be used to interact with the Fabric network and it will be exposed on port 3000. The configtxlator container will be used to generate and manage configuration transactions for the Fabric network and it will be exposed on port 7059.
+- `deployment.yaml`: Defines a StatefulSet with one replica that manages four containers: couchdb, fabric-console, fabric-deployer, and configtxlator. The couchdb container will be used to store the data for the Fabric network and it will be exposed on port 5984. The fabric-console container will be used to interact with the Fabric network and it will be exposed on port 3000. The fabric-deployer sidecar provides the backend APIs the console uses for orderer and channel workflows and listens on port 8080 inside the pod. The configtxlator container will be used to generate and manage configuration transactions for the Fabric network and it will be exposed on port 7059.
 - `pvc.yaml`: Defines a persistent volume claim that will be used to store the data for the CouchDB database.
-- `service.yaml`: configures a Kubernetes Service and an Ingress. The service has three ports: console (port 3000) is exposed for the fabric-console, couchdb (port 5984) is exposed for the couchdb database, and configtxlator (port 7059) is exposed for the configtxlator container. The service can be exposed in two ways: ClusterIP and NodePort. Optionally, if haproxy is selected, ingress will route traffic to the Service using the host and path.
+- `service.yaml`: configures a Kubernetes Service and an Ingress. The service has three externally exposed ports: console (port 3000) is exposed for the fabric-console, couchdb (port 5984) is exposed for the couchdb database, and configtxlator (port 7059) is exposed for the configtxlator container. The fabric-deployer sidecar is only used from inside the pod by the console. The service can be exposed in two ways: ClusterIP and NodePort. Optionally, if haproxy is selected, ingress will route traffic to the Service using the host and path.
 - `Chart.yaml`: Contains the metadata for the Helm chart, such as the name, version, and description.
 - `README.md`: Provides information and instructions about the Helm chart.
 - `values.yaml`: Contains the default configuration values for the Helm chart.
@@ -77,6 +77,7 @@ The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hy
 | namespace             | Provide the namespace for organization's peer                         | org1-net                                      |
 | images.couchdb        | Valid image name and version for fabric couchdb                       | couchdb:3.1.1                                         |
 | images.console        | Valid image name and version for fabric operations console            | ghcr.io/hyperledger-labs/fabric-console:latest        |
+| images.deployer       | Valid image name and version for the fabric deployer sidecar          | ghcr.io/ibm-blockchain/fabric-deployer:latest-amd64   |
 | images.configtxlator  | Valid image name and version to read certificates from vault server   | ghcr.io/hyperledger/bevel-fabric-tools:2.2.2                        |
 | labels                | Custom labels (other than predefined ones)                            | ""                                                    |
 
@@ -102,6 +103,7 @@ The [values.yaml](https://github.com/hyperledger/bevel/blob/develop/platforms/hy
 | ports.console.clusteripport   | Cluster IP port for grpc service                | 3000                |
 | ports.couchdb.nodeport        | NodePort for couchdb service (optional)         | ""                  |
 | ports.couchdb.clusteripport   | Cluster IP port for couchdb service             | 5984                |
+| ports.deployer.clusteripport  | Internal port for the fabric deployer sidecar   | 8080                |
 
 
 

--- a/platforms/hyperledger-fabric/charts/fabric-operations-console/templates/configmap.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-operations-console/templates/configmap.yaml
@@ -26,5 +26,6 @@ data:
     max_req_per_min: 100
     default_consortium: {{ $.Values.service.default_consortium }}
     configtxlator_url_original: http://{{ $.Values.service.name }}.{{ $.Values.metadata.namespace }}:7059
+    deployer_url: http://127.0.0.1:{{ $.Values.service.ports.deployer.clusteripport }}
     host_url: https://{{ $.Values.service.name }}.{{ $.Values.metadata.namespace }}.{{ $.Values.proxy.external_url_suffix }}
     default_user_password_initial: password

--- a/platforms/hyperledger-fabric/charts/fabric-operations-console/templates/deployment.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-operations-console/templates/deployment.yaml
@@ -82,6 +82,17 @@ spec:
         volumeMounts:         
         - name: {{ $.Values.service.name }}-config-volume
           mountPath: /home/athena/env
+      - name: fabric-deployer
+        image: {{ $.Values.metadata.images.deployer }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: deployer
+          containerPort: {{ $.Values.service.ports.deployer.clusteripport }}
+        env:
+        - name: LICENSE
+          value: "accept"
+        - name: DBCONNECTIONSTRING
+          value: "http://admin:password@127.0.0.1:5984"
       - name: configtxlator
         image: {{ $.Values.metadata.images.configtxlator }}
         imagePullPolicy: IfNotPresent        

--- a/platforms/hyperledger-fabric/charts/fabric-operations-console/values.yaml
+++ b/platforms/hyperledger-fabric/charts/fabric-operations-console/values.yaml
@@ -15,6 +15,9 @@ metadata:
     #Provide the valid image name and version for fabric operations console
     #Eg. hyperledgerlabs/fabric-console:latest
     console: ghcr.io/hyperledger-labs/fabric-console:latest
+    #Provide the valid image name and version for the fabric deployer sidecar
+    #Eg. ghcr.io/ibm-blockchain/fabric-deployer:latest-amd64
+    deployer: ghcr.io/ibm-blockchain/fabric-deployer:latest-amd64
     #Provide the valid image name and version to read certificates from vault server 
     #Eg. alpineutils: ghcr.io/hyperledger/bevel-alpine:latest
     configtxlator: ghcr.io/hyperledger/bevel-fabric-tools:2.2.2
@@ -66,6 +69,10 @@ service:
       #Provide a cluster IP port for couchdb service to be exposed
       #Eg. clusteripport: 5984
       clusteripport: 5984
+    deployer:
+      #Provide the internal port for the deployer sidecar
+      #Eg. clusteripport: 8080
+      clusteripport: 8080
       
 annotations:
   #Extra annotations


### PR DESCRIPTION
## Summary

Deploy the Fabric Operations Console with the missing `fabric-deployer` backend sidecar and point the console config at the in-pod deployer URL so channel and ordering-service workflows do not fall back to the default placeholder endpoint.

## Changes

- add the `fabric-deployer` sidecar container to the Fabric Operations Console StatefulSet
- configure the console with `deployer_url: http://127.0.0.1:8080`
- add chart values and docs for the deployer image and internal port

Fixes #2558